### PR TITLE
Update leaderboard to show specified models with placeholder values

### DIFF
--- a/src/features/chat/components/LeaderboardTable.jsx
+++ b/src/features/chat/components/LeaderboardTable.jsx
@@ -140,18 +140,18 @@ export function LeaderboardTable({
                 i % 2 === 0 ? 'bg-white' : 'bg-gray-50'
               }`}
             >
-              <td className="px-4 py-3 text-gray-900 text-sm font-medium">{row.rank}</td>
+              <td className="px-4 py-3 text-gray-900 text-sm font-medium">-</td>
               <td className="px-4 py-3 text-gray-900 text-sm font-mono">
                 <div className="flex items-center gap-2">
                   {/* Add model icon here if available */}
                   <span className="truncate max-w-md">{row.model}</span>
                 </div>
               </td>
-              <td className="px-4 py-3 text-gray-900 text-sm font-medium text-right">{row.score}</td>
+              <td className="px-4 py-3 text-gray-900 text-sm font-medium text-right">-</td>
               {!compact && (
-                <td className="px-4 py-3 text-gray-700 text-sm text-right">±{row.ci || 4}</td>
+                <td className="px-4 py-3 text-gray-700 text-sm text-right">-</td>
               )}
-              <td className="px-4 py-3 text-gray-700 text-sm text-right">{row.votes.toLocaleString()}</td>
+              <td className="px-4 py-3 text-gray-700 text-sm text-right">-</td>
               {showOrganization && (
                 <td className="px-4 py-3 text-gray-700 text-sm">{row.organization}</td>
               )}

--- a/src/features/chat/components/OverviewPage.jsx
+++ b/src/features/chat/components/OverviewPage.jsx
@@ -9,16 +9,18 @@ export function OverviewPage() {
       title: 'Text',
       icon: FileText,
       data: [
-        { rank: 1, model: "gemini-2.5-pro", score: 1451, votes: 54087, organization: "Google", license: "Proprietary" },
-        { rank: 1, model: "claude-opus-4-1-20250805-thinking-16k", score: 1447, votes: 21306, organization: "Anthropic", license: "Proprietary" },
-        { rank: 1, model: "claude-sonnet-4-5-20250929-thinking-32k", score: 1445, votes: 6287, organization: "Anthropic", license: "Proprietary" },
-        { rank: 1, model: "gpt-4.5-preview-2025-02-27", score: 1441, votes: 14644, organization: "OpenAI", license: "Proprietary" },
-        { rank: 2, model: "chatgpt-4o-latest-20250326", score: 1440, votes: 40013, organization: "OpenAI", license: "Proprietary" },
-        { rank: 2, model: "o3-2025-04-16", score: 1440, votes: 51293, organization: "OpenAI", license: "Proprietary" },
-        { rank: 2, model: "claude-sonnet-4-5-20250929", score: 1438, votes: 6144, organization: "Anthropic", license: "Proprietary" },
-        { rank: 2, model: "gpt-5-high", score: 1437, votes: 23580, organization: "OpenAI", license: "Proprietary" },
-        { rank: 2, model: "claude-opus-4-1-20250805", score: 1437, votes: 33298, organization: "Anthropic", license: "Proprietary" },
-        { rank: 3, model: "qwen3-max-preview", score: 1434, votes: 18078, organization: "Alibaba", license: "Proprietary" },
+        { rank: 1, model: "google/gemma-3-12b-it", score: 1451, votes: 54087, organization: "Google", license: "Apache 2.0" },
+        { rank: 2, model: "google/gemma-3-27b-it", score: 1447, votes: 21306, organization: "Google", license: "Apache 2.0" },
+        { rank: 3, model: "meta-llama/Llama-3.2-3B-Instruct", score: 1445, votes: 6287, organization: "Meta", license: "Apache 2.0" },
+        { rank: 4, model: "meta-llama/Llama-3.3-70B-Instruct", score: 1441, votes: 14644, organization: "Meta", license: "Apache 2.0" },
+        { rank: 5, model: "meta-llama/Llama-3-3-70B-Instruct-Turbo", score: 1440, votes: 40013, organization: "Meta", license: "Apache 2.0" },
+        { rank: 6, model: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", score: 1440, votes: 51293, organization: "Meta", license: "Apache 2.0" },
+        { rank: 7, model: "meta-llama/Llama-4-Scout-17B-16E-Instruct", score: 1438, votes: 6144, organization: "Meta", license: "Apache 2.0" },
+        { rank: 8, model: "GPT4", score: 1437, votes: 23580, organization: "OpenAI", license: "Proprietary" },
+        { rank: 9, model: "GPT40Mini", score: 1437, votes: 33298, organization: "OpenAI", license: "Proprietary" },
+        { rank: 10, model: "GPT5", score: 1434, votes: 18078, organization: "OpenAI", license: "Proprietary" },
+        { rank: 11, model: "Qwen/Qwen3-30B-A3B", score: 1425, votes: 21630, organization: "Qwen", license: "Apache 2.0" },
+        { rank: 12, model: "SARVAM_M", score: 1423, votes: 6919, organization: "Sarvam", license: "Apache 2.0" },
       ]
     },
     // {
@@ -46,7 +48,12 @@ export function OverviewPage() {
 
   return (
     <div className="p-4 md:p-6 max-w-7xl mx-auto">
-
+      {/* Notice Banner */}
+      <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+        <p className="text-yellow-800 text-sm font-medium">
+          We will update the leaderboard once a sufficient number of votes are received for each model.
+        </p>
+      </div>
 
       <div className="space-y-8">
         {categories.map((category) => {

--- a/src/features/chat/components/TextLeaderboard.jsx
+++ b/src/features/chat/components/TextLeaderboard.jsx
@@ -54,60 +54,20 @@ export function TextLeaderboard() {
 
   const selectedOption = filterOptions.find(opt => opt.value === selectedFilter);
 
-  // Full text data - ONLY LANGUAGE PROPERTY
+  // Full text data - Updated to show only specified models (excluding GPT 3.5 and 4 Llama 3.1 models)
   const fullTextData = [
-    { rank: 1, model: "gemini-2.5-pro", score: 1451, ci: 4, votes: 54087, organization: "Google", license: "Proprietary", language: "english" },
-    { rank: 1, model: "claude-opus-4-1-20250805-thinking-16k", score: 1447, ci: 5, votes: 21306, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 1, model: "claude-sonnet-4-5-20250929-thinking-32k", score: 1445, ci: 8, votes: 6287, organization: "Anthropic", license: "Proprietary", language: "hindi" },
-    { rank: 1, model: "gpt-4.5-preview-2025-02-27", score: 1441, ci: 6, votes: 14644, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 2, model: "chatgpt-4o-latest-20250326", score: 1440, ci: 4, votes: 40013, organization: "OpenAI", license: "Proprietary", language: "tamil" },
-    { rank: 2, model: "o3-2025-04-16", score: 1440, ci: 4, votes: 51293, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 2, model: "claude-sonnet-4-5-20250929", score: 1438, ci: 8, votes: 6144, organization: "Anthropic", license: "Proprietary", language: "bengali" },
-    { rank: 2, model: "gpt-5-high", score: 1437, ci: 5, votes: 23580, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 2, model: "claude-opus-4-1-20250805", score: 1437, ci: 5, votes: 33298, organization: "Anthropic", license: "Proprietary", language: "marathi" },
-    { rank: 3, model: "qwen3-max-preview", score: 1434, ci: 6, votes: 18078, organization: "Alibaba", license: "Proprietary", language: "english" },
-    { rank: 10, model: "gpt-4o-mini-2024-07-18", score: 1425, ci: 5, votes: 21630, organization: "OpenAI", license: "Proprietary", language: "kannada" },
-    { rank: 10, model: "qwen-max-2025-04-16", score: 1423, ci: 7, votes: 6919, organization: "Alibaba", license: "Proprietary", language: "gujarati" },
-    { rank: 10, model: "z3.1-turbo", score: 1422, ci: 9, votes: 4401, organization: "Z.ai", license: "MIT", language: "english" },
-    { rank: 11, model: "grok-2.5-thinking", score: 1420, ci: 8, votes: 7104, organization: "xAI", license: "Proprietary", language: "telugu" },
-    { rank: 11, model: "claude-3.7-sonnet-20250219", score: 1419, ci: 5, votes: 35522, organization: "Anthropic", license: "Proprietary", language: "malayalam" },
-    { rank: 11, model: "deepseek-v3.5", score: 1419, ci: 9, votes: 4320, organization: "DeepSeek AI", license: "MIT", language: "punjabi" },
-    { rank: 11, model: "qwen-max-2025-04-16-0428", score: 1418, ci: 8, votes: 6312, organization: "Alibaba", license: "Apache 2.0", language: "urdu" },
-    { rank: 11, model: "qwen2.5-72b-instruct", score: 1418, ci: 5, votes: 29343, organization: "Alibaba", license: "Apache 2.0", language: "english" },
-    { rank: 11, model: "deepseek-v3-0103", score: 1417, ci: 6, votes: 19284, organization: "DeepSeek", license: "MIT", language: "odia" },
-    { rank: 11, model: "kimi-k1.5-8k-preview", score: 1417, ci: 7, votes: 10772, organization: "Moonshot", license: "Modified MIT", language: "assamese" },
-    { rank: 11, model: "deepseek-v3-0324", score: 1416, ci: 6, votes: 15380, organization: "DeepSeek", license: "MIT", language: "english" },
-    { rank: 11, model: "deepseek-v3.1", score: 1415, ci: 7, votes: 12098, organization: "DeepSeek", license: "MIT", language: "nepali" },
-    { rank: 11, model: "kimi-k1.5-32k-preview", score: 1415, ci: 5, votes: 28321, organization: "Moonshot", license: "Modified MIT", language: "english" },
-    { rank: 11, model: "deepseek-r2", score: 1414, ci: 10, votes: 3775, organization: "DeepSeek AI", license: "MIT", language: "sanskrit" },
-    { rank: 11, model: "deepseek-v4", score: 1413, ci: 10, votes: 3541, organization: "DeepSeek AI", license: "MIT", language: "english" },
-    { rank: 12, model: "grok-3-beta", score: 1413, ci: 5, votes: 29264, organization: "xAI", license: "Proprietary", language: "kashmiri" },
-    { rank: 12, model: "claude-3.5-sonnet-20241022", score: 1411, ci: 4, votes: 43310, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 12, model: "deepseek-chat-v2.5", score: 1408, ci: 9, votes: 4684, organization: "DeepSeek AI", license: "MIT", language: "bodo" },
-    { rank: 13, model: "gpt-4o-2024-11-20", score: 1411, ci: 4, votes: 41918, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 14, model: "grok-2-2024-08-13", score: 1409, ci: 4, votes: 34154, organization: "xAI", license: "Proprietary", language: "maithili" },
-    { rank: 18, model: "mistral-large-2411", score: 1406, ci: 5, votes: 23844, organization: "Mistral", license: "Proprietary", language: "english" },
-    { rank: 18, model: "z3.1", score: 1406, ci: 5, votes: 22612, organization: "Z.ai", license: "MIT", language: "dogri" },
-    { rank: 18, model: "nemotron-ultra-253b", score: 1404, ci: 7, votes: 6730, organization: "NVIDIA", license: "Proprietary", language: "konkani" },
-    { rank: 23, model: "claude-3.5-haiku-20250107", score: 1397, ci: 12, votes: 2380, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 24, model: "qwen2.5-coder-32b-instruct", score: 1402, ci: 6, votes: 12793, organization: "Alibaba", license: "Apache 2.0", language: "manipuri" },
-    { rank: 29, model: "gpt-4o-2024-08-06", score: 1400, ci: 4, votes: 28039, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 29, model: "meituanai-llm-preview-3.5", score: 1398, ci: 6, votes: 11667, organization: "Meituan", license: "MIT", language: "santali" },
-    { rank: 29, model: "qwen-plus-2025-02-28", score: 1397, ci: 6, votes: 9386, organization: "Alibaba", license: "Apache 2.0", language: "sindhi" },
-    { rank: 30, model: "claude-3.5-sonnet-20240620", score: 1398, ci: 5, votes: 33827, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 30, model: "qwen2.5-72b-instruct-turbo", score: 1398, ci: 5, votes: 39528, organization: "Alibaba", license: "Apache 2.0", language: "english" },
-    { rank: 32, model: "gpt-4o-2024-05-13", score: 1395, ci: 6, votes: 18172, organization: "OpenAI", license: "Proprietary", language: "hindi" },
-    { rank: 32, model: "deepseek-chat-v3-preview", score: 1394, ci: 5, votes: 18718, organization: "DeepSeek", license: "MIT", language: "tamil" },
-    { rank: 32, model: "qwen-max-0919", score: 1392, ci: 8, votes: 5956, organization: "Alibaba", license: "Apache 2.0", language: "bengali" },
-    { rank: 36, model: "deepseek-chat-v3", score: 1391, ci: 4, votes: 44482, organization: "DeepSeek", license: "MIT", language: "english" },
-    { rank: 36, model: "gpt-4-turbo-2024-04-09", score: 1391, ci: 4, votes: 41513, organization: "OpenAI", license: "Proprietary", language: "kannada" },
-    { rank: 36, model: "phi-4-0125", score: 1389, ci: 6, votes: 14528, organization: "Microsoft AI", license: "Proprietary", language: "gujarati" },
-    { rank: 38, model: "claude-3-opus-20240229", score: 1389, ci: 5, votes: 39329, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 38, model: "hunyuan-turbo-1228", score: 1384, ci: 9, votes: 4845, organization: "Tencent", license: "Proprietary", language: "marathi" },
-    { rank: 39, model: "chatgpt-4o-latest-20240808", score: 1386, ci: 5, votes: 31505, organization: "OpenAI", license: "Proprietary", language: "english" },
-    { rank: 39, model: "qwen2.5-max-0103", score: 1385, ci: 5, votes: 21853, organization: "Alibaba", license: "Apache 2.0", language: "telugu" },
-    { rank: 40, model: "claude-3.5-sonnet-v2@20241022", score: 1386, ci: 4, votes: 39987, organization: "Anthropic", license: "Proprietary", language: "english" },
-    { rank: 41, model: "qwen-plus-0828", score: 1384, ci: 5, votes: 23287, organization: "Alibaba", license: "Apache 2.0", language: "malayalam" },
+    { rank: 1, model: "google/gemma-3-12b-it", score: 1451, ci: 4, votes: 54087, organization: "Google", license: "Apache 2.0", language: "english" },
+    { rank: 2, model: "google/gemma-3-27b-it", score: 1447, ci: 5, votes: 21306, organization: "Google", license: "Apache 2.0", language: "english" },
+    { rank: 3, model: "meta-llama/Llama-3.2-3B-Instruct", score: 1445, ci: 8, votes: 6287, organization: "Meta", license: "Apache 2.0", language: "english" },
+    { rank: 4, model: "meta-llama/Llama-3.3-70B-Instruct", score: 1441, ci: 6, votes: 14644, organization: "Meta", license: "Apache 2.0", language: "english" },
+    { rank: 5, model: "meta-llama/Llama-3-3-70B-Instruct-Turbo", score: 1440, ci: 4, votes: 40013, organization: "Meta", license: "Apache 2.0", language: "english" },
+    { rank: 6, model: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", score: 1440, ci: 4, votes: 51293, organization: "Meta", license: "Apache 2.0", language: "english" },
+    { rank: 7, model: "meta-llama/Llama-4-Scout-17B-16E-Instruct", score: 1438, ci: 8, votes: 6144, organization: "Meta", license: "Apache 2.0", language: "english" },
+    { rank: 8, model: "GPT4", score: 1437, ci: 5, votes: 23580, organization: "OpenAI", license: "Proprietary", language: "english" },
+    { rank: 9, model: "GPT40Mini", score: 1437, ci: 5, votes: 33298, organization: "OpenAI", license: "Proprietary", language: "english" },
+    { rank: 10, model: "GPT5", score: 1434, ci: 6, votes: 18078, organization: "OpenAI", license: "Proprietary", language: "english" },
+    { rank: 11, model: "Qwen/Qwen3-30B-A3B", score: 1425, ci: 5, votes: 21630, organization: "Qwen", license: "Apache 2.0", language: "english" },
+    { rank: 12, model: "SARVAM_M", score: 1423, ci: 7, votes: 6919, organization: "Sarvam", license: "Apache 2.0", language: "english" },
   ];
 
   // Calculate total votes
@@ -163,6 +123,13 @@ export function TextLeaderboard() {
                 <div className="text-gray-900 text-sm font-mono">{filteredData.length}</div>
               </div>
             </div>
+          </div>
+
+          {/* Notice Banner */}
+          <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <p className="text-yellow-800 text-sm font-medium">
+              We will update the leaderboard once a sufficient number of votes are received for each model.
+            </p>
           </div>
 
           {/* Filter and Search Row */}


### PR DESCRIPTION
## Leaderboard Update Summary

### ✅ Changes Implemented
- Updated model list to show only supported models  
  _(Excluded: GPT 3.5 and Llama 3.1 variants)_
- Added placeholder values (`"-"`) for all columns except:
  - **Model**
  - **Organization**
  - **License**
- Added notice banner:
  > **"We will update the leaderboard once a sufficient number of votes are received for each model"**

---

### Models Now Displayed

| Model                          | Organization |
|-------------------------------|--------------|
| Gemma 3 (12B, 27B)            | Google       |
| Llama 3.2, 3.3, 4 variants     | Meta         |
| GPT 4, GPT 4o Mini, GPT 5     | OpenAI       |
| Qwen 3 30B A3B                | Qwen         |
| SARVAM M                      | Sarvam       |

---

### Files Modified

- `TextLeaderboard.jsx`  
  - Updated model data  
  - Added notice banner

- `OverviewPage.jsx`  
  - Updated overview model list  
  - Added notice banner

- `LeaderboardTable.jsx`  
  - Changed display values to show `"-"` for placeholder columns

