### PR TITLE
fix: prevent auto-scroll interference during response streaming

### DIFF
--- a/src/features/chat/components/CompareView.jsx
+++ b/src/features/chat/components/CompareView.jsx
@@ -25,16 +25,28 @@ export function CompareView({ session, messages, streamingMessages, onRegenerate
     setExpandedMessage(null);
   };
 
+  // Auto-scroll logic - only for new messages, not streaming updates
   useEffect(() => {
     if (!isUserScrolledUp) {
       endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages, streamingMessages, isUserScrolledUp]);
+  }, [messages, isUserScrolledUp]); // Removed streamingMessages from dependency
+
+  // Throttled auto-scroll for streaming - less aggressive
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!isUserScrolledUp && Object.keys(streamingMessages).length > 0) {
+        endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, 500); // Only auto-scroll every 500ms during streaming
+
+    return () => clearTimeout(timer);
+  }, [streamingMessages, isUserScrolledUp]);
 
   const handleMainScroll = () => {
     const el = mainScrollRef.current;
     if (el) {
-      const isAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 50;
+      const isAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 100; // Increased threshold
       setIsUserScrolledUp(!isAtBottom);
     }
   };

--- a/src/features/chat/components/MessageList.jsx
+++ b/src/features/chat/components/MessageList.jsx
@@ -10,16 +10,29 @@ export function MessageList({ messages, streamingMessages, session, onExpand, on
     isRegenerating: state.chat.isRegenerating,
     selectedMode: state.chat.selectedMode,
   }));
+  
+  // Auto-scroll logic - only for new messages, not streaming updates
   useEffect(() => {
     if (!isUserScrolledUp) {
       endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages, streamingMessages, isUserScrolledUp]);
+  }, [messages, isUserScrolledUp]); // Removed streamingMessages from dependency
+
+  // Throttled auto-scroll for streaming - less aggressive
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!isUserScrolledUp && Object.keys(streamingMessages).length > 0) {
+        endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, 500); // Only auto-scroll every 500ms during streaming
+
+    return () => clearTimeout(timer);
+  }, [streamingMessages, isUserScrolledUp]);
 
   const handleMainScroll = () => {
     const el = mainScrollRef.current;
     if (el) {
-      const isAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 50;
+      const isAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 100; // Increased threshold
       setIsUserScrolledUp(!isAtBottom);
     }
   };


### PR DESCRIPTION
#### Fixes scroll lock issue during AI response streaming. Users can now scroll up to read previous messages while responses are being generated, instead of being forced to stay at the bottom.