### PR TITLE
feat(eduviz): Complete Eduviz Benchmark UI

### DIFF
--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -9,6 +9,7 @@ import { AudioVisualization } from '../features/asr/components/AudioVisualizatio
 import { TtsLayout } from '../features/tts/components/TtsLayout';
 import { TtsAcademicLayout } from '../features/tts/components/TtsAcademicLayout';
 import { OcrLayout } from '../features/ocr/components/OcrLayout';
+import { EduVizLayout } from '../features/eduviz/components/EduVizLayout';
 import { useTenant } from '../shared/context/TenantContext';
 
 // Wrapper that extracts tenant from URL and sets context
@@ -47,6 +48,8 @@ export function AppRouter() {
       <Route path="/ocr/:sessionId" element={<OcrLayout />} />
       <Route path="/leaderboard/ocr" element={<OcrLayout />} />
       <Route path="/leaderboard/ocr/:category" element={<OcrLayout />} />
+      <Route path="/eduviz" element={<EduVizLayout />} />
+      <Route path="/eduviz/:sessionId" element={<EduVizLayout />} />
       <Route path="/shared/:shareToken" element={<SharedSessionView />} />
       <Route path="/privacy" element={<PrivacyPolicyPage />} />
       <Route path="/terms" element={<TermsOfServicePage />} />
@@ -69,6 +72,8 @@ export function AppRouter() {
       <Route path="/:tenant/ocr/:sessionId" element={<TenantRoute><OcrLayout /></TenantRoute>} />
       <Route path="/:tenant/leaderboard/ocr" element={<TenantRoute><OcrLayout /></TenantRoute>} />
       <Route path="/:tenant/leaderboard/ocr/:category" element={<TenantRoute><OcrLayout /></TenantRoute>} />
+      <Route path="/:tenant/eduviz" element={<TenantRoute><EduVizLayout /></TenantRoute>} />
+      <Route path="/:tenant/eduviz/:sessionId" element={<TenantRoute><EduVizLayout /></TenantRoute>} />
       <Route path="/:tenant/shared/:shareToken" element={<TenantRoute><SharedSessionView /></TenantRoute>} />
     </Routes >
   );

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -4,6 +4,7 @@ import llmChatReducer from '../features/chat/store/chatSlice';
 import ttsChatReducer from '../features/tts/store/chatSlice';
 import asrChatReducer from '../features/asr/store/chatSlice';
 import ocrChatReducer from '../features/ocr/store/chatSlice';
+import eduvizReducer from '../features/eduviz/store/eduvizSlice';
 import modelsReducer from '../features/models/store/modelsSlice';
 import { setLogoutCallback } from '../shared/api/client';
 
@@ -14,6 +15,7 @@ export const store = configureStore({
     ttsChat: ttsChatReducer,
     asrChat: asrChatReducer,
     ocrChat: ocrChatReducer,
+    eduviz: eduvizReducer,
     models: modelsReducer,
   },
 });

--- a/src/features/eduviz/components/EduVizAssessmentPanel.jsx
+++ b/src/features/eduviz/components/EduVizAssessmentPanel.jsx
@@ -79,21 +79,21 @@ export function EduVizAssessmentPanel() {
   return (
     <div className="flex flex-col h-full bg-white relative">
       {/* Header */}
-      <div className="px-5 py-4 border-b border-gray-100 flex-shrink-0 bg-gray-50/50">
-        <div className="flex items-center gap-2.5 flex-wrap">
+      <div className="px-4 sm:px-5 py-3 sm:py-4 border-b border-gray-100 flex-shrink-0 bg-gray-50/50">
+        <div className="flex items-center gap-2 sm:gap-2.5 flex-wrap">
           <div className="flex gap-1.5 mr-1">
             {labels.map((label, idx) => (
               <div 
                 key={idx} 
-                className="w-2.5 h-2.5 rounded-full shadow-sm" 
+                className="w-2 sm:w-2.5 h-2 sm:h-2.5 rounded-full shadow-sm" 
                 style={{ backgroundColor: getEduvizTypeColor(label) }} 
               />
             ))}
             {labels.length === 0 && (
-               <div className="w-2.5 h-2.5 rounded-full shadow-sm bg-gray-200" />
+               <div className="w-2 sm:w-2.5 h-2 sm:h-2.5 rounded-full shadow-sm bg-gray-200" />
             )}
           </div>
-          <h2 className="text-[13px] font-bold text-gray-800 uppercase tracking-widest break-words flex-1">
+          <h2 className="text-[11px] sm:text-[13px] font-bold text-gray-800 uppercase tracking-widest break-words flex-1">
             {currentAnnotation ? `Assessing: ${displayTitle}` : 'Assessment Panel'}
           </h2>
         </div>
@@ -125,14 +125,14 @@ export function EduVizAssessmentPanel() {
 
           {/* Suggested Improvement */}
           <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-widest mb-2">
+            <label className="block text-[10px] sm:text-xs font-semibold text-gray-500 uppercase tracking-widest mb-2">
               Suggested Improvement
             </label>
             <textarea
               value={assessment.suggestedImprovement}
               onChange={(e) => handleUpdate({ suggestedImprovement: e.target.value })}
               placeholder="How could the student improve this block?"
-              rows={3}
+              rows={2}
               className="w-full px-4 py-3 text-sm text-gray-800 bg-white border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 shadow-sm placeholder:text-gray-400 transition-all duration-200"
             />
           </div>

--- a/src/features/eduviz/components/EduVizAssessmentPanel.jsx
+++ b/src/features/eduviz/components/EduVizAssessmentPanel.jsx
@@ -1,14 +1,20 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
 import { StarRating } from './StarRating';
-import { updateAnnotationAssessment } from '../store/eduvizSlice';
+import { updateAnnotationAssessment, submitAssessment, setSubmitStatus } from '../store/eduvizSlice';
+import { getEduvizTypeColor, getEduvizTypeLabel } from '../utils/eduvizTypeColors';
 
 export function EduVizAssessmentPanel() {
   const dispatch = useDispatch();
   const {
+    metadata,
+    submitStatus,
     activeSession,
     currentPageIndex,
     annotations,
     selectedAnnotationId,
+    annotationMessageIds,
     editedAnnotations,
   } = useSelector(s => s.eduviz);
 
@@ -17,14 +23,36 @@ export function EduVizAssessmentPanel() {
   const participant = 'modelA';
 
   // Read assessment from the currently selected annotation (if any)
-  const currentAnnotation = selectedAnnotationId && pageKey 
-    ? editedAnnotations[pageKey]?.[participant]?.[selectedAnnotationId] 
+  const currentAnnotation = selectedAnnotationId && pageKey
+    ? editedAnnotations[pageKey]?.[participant]?.[selectedAnnotationId]
     : null;
 
   const assessment = currentAnnotation?.assessment || {
     whyIncorrect: '',
     suggestedImprovement: '',
     rubrics: { legibility: 0, spellingAccuracy: 0, contentCorrectness: 0 },
+  };
+
+  const messageId = pageKey ? annotationMessageIds?.[pageKey]?.[participant] : null;
+  const annotatedBlocks = pageKey ? Object.values(editedAnnotations[pageKey]?.[participant] || {}) : [];
+
+  // Reset submit status after 3 seconds
+  useEffect(() => {
+    if (submitStatus === 'saved' || submitStatus === 'error') {
+      const timer = setTimeout(() => dispatch(setSubmitStatus('idle')), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [submitStatus, dispatch]);
+
+  const handleSubmit = () => {
+    if (!messageId) return;
+    dispatch(submitAssessment({
+      messageId,
+      assessment: {
+        metadata,
+        annotatedBlocks,
+      },
+    }));
   };
 
   const handleUpdate = (updates) => {
@@ -37,19 +65,44 @@ export function EduVizAssessmentPanel() {
     }));
   };
 
+  // Extract display label and color matching the canvas pill
+  const labels = currentAnnotation?.labels || (currentAnnotation?.type ? [currentAnnotation.type] : []);
+  
+  const getLabelText = (type) => {
+    return type.includes('_error') ? getEduvizTypeLabel(type) : (type.charAt(0).toUpperCase() + type.slice(1) || 'Block');
+  };
+
+  const displayTitle = labels.length > 0 
+    ? labels.map(getLabelText).join(', ')
+    : 'Block';
+
   return (
     <div className="flex flex-col h-full bg-white relative">
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-100 flex-shrink-0">
-        <h2 className="text-sm font-bold text-gray-800 uppercase tracking-wide">
-          {currentAnnotation ? `Assessing: ${(currentAnnotation.type || 'Block').charAt(0).toUpperCase() + (currentAnnotation.type || 'Block').slice(1)}` : 'Assessment Panel'}
-        </h2>
+      <div className="px-5 py-4 border-b border-gray-100 flex-shrink-0 bg-gray-50/50">
+        <div className="flex items-center gap-2.5 flex-wrap">
+          <div className="flex gap-1.5 mr-1">
+            {labels.map((label, idx) => (
+              <div 
+                key={idx} 
+                className="w-2.5 h-2.5 rounded-full shadow-sm" 
+                style={{ backgroundColor: getEduvizTypeColor(label) }} 
+              />
+            ))}
+            {labels.length === 0 && (
+               <div className="w-2.5 h-2.5 rounded-full shadow-sm bg-gray-200" />
+            )}
+          </div>
+          <h2 className="text-[13px] font-bold text-gray-800 uppercase tracking-widest break-words flex-1">
+            {currentAnnotation ? `Assessing: ${displayTitle}` : 'Assessment Panel'}
+          </h2>
+        </div>
       </div>
 
       {!selectedAnnotationId ? (
         <div className="flex-1 flex flex-col items-center justify-center text-center p-8 text-gray-400">
           <div className="w-16 h-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center mb-4">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-300"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><path d="M8 13h2"/><path d="M8 17h2"/><path d="M14 13h2"/><path d="M14 17h2"/></svg>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-300"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" /><polyline points="14 2 14 8 20 8" /><path d="M8 13h2" /><path d="M8 17h2" /><path d="M14 13h2" /><path d="M14 17h2" /></svg>
           </div>
           <p className="text-sm font-medium text-gray-600 mb-1">No Block Selected</p>
           <p className="text-xs text-gray-400">Click on any text, diagram, or drawn error box on the document to evaluate it.</p>
@@ -58,7 +111,7 @@ export function EduVizAssessmentPanel() {
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-5 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-300/50 [&::-webkit-scrollbar-thumb]:rounded-full pb-8">
           {/* Why Incorrect */}
           <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-widest mb-2">
               Why Incorrect / Notes?
             </label>
             <textarea
@@ -66,13 +119,13 @@ export function EduVizAssessmentPanel() {
               onChange={(e) => handleUpdate({ whyIncorrect: e.target.value })}
               placeholder="Provide notes or describe any errors found..."
               rows={3}
-              className="w-full px-3 py-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 placeholder:text-gray-400"
+              className="w-full px-4 py-3 text-sm text-gray-800 bg-white border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 shadow-sm placeholder:text-gray-400 transition-all duration-200"
             />
           </div>
 
           {/* Suggested Improvement */}
           <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-widest mb-2">
               Suggested Improvement
             </label>
             <textarea
@@ -80,7 +133,7 @@ export function EduVizAssessmentPanel() {
               onChange={(e) => handleUpdate({ suggestedImprovement: e.target.value })}
               placeholder="How could the student improve this block?"
               rows={3}
-              className="w-full px-3 py-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 placeholder:text-gray-400"
+              className="w-full px-4 py-3 text-sm text-gray-800 bg-white border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 shadow-sm placeholder:text-gray-400 transition-all duration-200"
             />
           </div>
 
@@ -107,6 +160,30 @@ export function EduVizAssessmentPanel() {
               />
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Submit Button locked to bottom of assessment panel */}
+      {selectedAnnotationId && (
+        <div className="p-4 border-t border-gray-100 bg-gray-50 flex-shrink-0 mt-auto">
+          <button
+            onClick={handleSubmit}
+            disabled={!messageId || submitStatus === 'saving'}
+            className={`w-full flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl text-[13px] font-bold tracking-wide transition-all duration-300 shadow-md ${submitStatus === 'saved'
+              ? 'bg-emerald-500 hover:bg-emerald-600 shadow-emerald-500/25 text-white'
+              : submitStatus === 'error'
+                ? 'bg-rose-500 hover:bg-rose-600 shadow-rose-500/25 text-white'
+                : 'bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 shadow-orange-500/20 hover:shadow-orange-500/40 text-white disabled:opacity-40 disabled:cursor-not-allowed'
+              }`}
+          >
+            {submitStatus === 'saving' && <Loader2 size={16} className="animate-spin" />}
+            {submitStatus === 'saved' && <CheckCircle2 size={16} />}
+            {submitStatus === 'error' && <AlertCircle size={16} />}
+            {submitStatus === 'saving' ? 'Saving…' :
+              submitStatus === 'saved' ? 'Saved!' :
+                submitStatus === 'error' ? 'Error' :
+                  'Submit Annotation'}
+          </button>
         </div>
       )}
     </div>

--- a/src/features/eduviz/components/EduVizAssessmentPanel.jsx
+++ b/src/features/eduviz/components/EduVizAssessmentPanel.jsx
@@ -1,0 +1,114 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { StarRating } from './StarRating';
+import { updateAnnotationAssessment } from '../store/eduvizSlice';
+
+export function EduVizAssessmentPanel() {
+  const dispatch = useDispatch();
+  const {
+    activeSession,
+    currentPageIndex,
+    annotations,
+    selectedAnnotationId,
+    editedAnnotations,
+  } = useSelector(s => s.eduviz);
+
+  const sessionId = activeSession?.id;
+  const pageKey = sessionId ? `${sessionId}_${currentPageIndex}` : null;
+  const participant = 'modelA';
+
+  // Read assessment from the currently selected annotation (if any)
+  const currentAnnotation = selectedAnnotationId && pageKey 
+    ? editedAnnotations[pageKey]?.[participant]?.[selectedAnnotationId] 
+    : null;
+
+  const assessment = currentAnnotation?.assessment || {
+    whyIncorrect: '',
+    suggestedImprovement: '',
+    rubrics: { legibility: 0, spellingAccuracy: 0, contentCorrectness: 0 },
+  };
+
+  const handleUpdate = (updates) => {
+    if (!selectedAnnotationId) return;
+    dispatch(updateAnnotationAssessment({
+      sessionId: pageKey, // wait! The reducer takes sessionId from payload but uses it as the dictionary key, which we have named pageKey here
+      participant,
+      annotationId: selectedAnnotationId,
+      assessmentUpdate: updates
+    }));
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-white relative">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-gray-100 flex-shrink-0">
+        <h2 className="text-sm font-bold text-gray-800 uppercase tracking-wide">
+          {currentAnnotation ? `Assessing: ${(currentAnnotation.type || 'Block').charAt(0).toUpperCase() + (currentAnnotation.type || 'Block').slice(1)}` : 'Assessment Panel'}
+        </h2>
+      </div>
+
+      {!selectedAnnotationId ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-center p-8 text-gray-400">
+          <div className="w-16 h-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center mb-4">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-300"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><path d="M8 13h2"/><path d="M8 17h2"/><path d="M14 13h2"/><path d="M14 17h2"/></svg>
+          </div>
+          <p className="text-sm font-medium text-gray-600 mb-1">No Block Selected</p>
+          <p className="text-xs text-gray-400">Click on any text, diagram, or drawn error box on the document to evaluate it.</p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-5 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-300/50 [&::-webkit-scrollbar-thumb]:rounded-full pb-8">
+          {/* Why Incorrect */}
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+              Why Incorrect / Notes?
+            </label>
+            <textarea
+              value={assessment.whyIncorrect}
+              onChange={(e) => handleUpdate({ whyIncorrect: e.target.value })}
+              placeholder="Provide notes or describe any errors found..."
+              rows={3}
+              className="w-full px-3 py-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 placeholder:text-gray-400"
+            />
+          </div>
+
+          {/* Suggested Improvement */}
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+              Suggested Improvement
+            </label>
+            <textarea
+              value={assessment.suggestedImprovement}
+              onChange={(e) => handleUpdate({ suggestedImprovement: e.target.value })}
+              placeholder="How could the student improve this block?"
+              rows={3}
+              className="w-full px-3 py-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 placeholder:text-gray-400"
+            />
+          </div>
+
+          {/* Scoring Rubrics */}
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+              Scoring Rubrics
+            </label>
+            <div className="space-y-3">
+              <StarRating
+                label="Legibility"
+                score={assessment.rubrics.legibility}
+                onChange={(score) => handleUpdate({ rubrics: { legibility: score } })}
+              />
+              <StarRating
+                label="Spelling Accuracy"
+                score={assessment.rubrics.spellingAccuracy}
+                onChange={(score) => handleUpdate({ rubrics: { spellingAccuracy: score } })}
+              />
+              <StarRating
+                label="Content Correctness"
+                score={assessment.rubrics.contentCorrectness}
+                onChange={(score) => handleUpdate({ rubrics: { contentCorrectness: score } })}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizDocumentView.jsx
+++ b/src/features/eduviz/components/EduVizDocumentView.jsx
@@ -43,6 +43,16 @@ export function EduVizDocumentView({ sessionId }) {
   const refImgRef = useRef(null);
   const refContainerRef = useRef(null);
   const [refZoom, setRefZoom] = useState(1.0);
+  
+  // Responsive states
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 1024);
+  const [activeTab, setActiveTab] = useState('submission'); // 'reference' | 'submission' | 'assessment'
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 1024);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const currentPage = pages[currentPageIndex];
   const pageKey = `${sessionId}_${currentPageIndex}`;
@@ -169,140 +179,174 @@ export function EduVizDocumentView({ sessionId }) {
   const centerPct = Math.max(MIN_CENTER_PCT, 100 - leftPct - rightPct);
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex-1 flex flex-col overflow-hidden bg-gray-50">
+      
+      {/* Mobile Tab Switcher */}
+      {isMobile && (
+        <div className="flex-shrink-0 bg-white border-b border-gray-200 flex p-1 gap-1">
+          {[
+            { id: 'reference', label: 'Reference' },
+            { id: 'submission', label: 'Submission' },
+            { id: 'assessment', label: 'Assessment' }
+          ].map(tab => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex-1 py-2 text-[11px] font-bold uppercase tracking-wider rounded-lg transition-all ${
+                activeTab === tab.id 
+                  ? 'bg-orange-500 text-white shadow-sm' 
+                  : 'text-gray-500 hover:bg-gray-100'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Three panes */}
-      <div ref={containerRef} className="flex flex-1 overflow-hidden">
+      <div ref={containerRef} className="flex flex-1 overflow-hidden relative">
 
-        {/* LEFT: Reference Material */}
-        <div
-          className="relative overflow-hidden flex-shrink-0 border-r border-gray-200"
-          style={{ width: `${leftPct}%` }}
-        >
-          <div className="absolute top-0 left-0 right-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
-            <span className="text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
-              Reference Material
-            </span>
-          </div>
+        {(!isMobile || activeTab === 'reference') && (
           <div
-            ref={refContainerRef}
-            className="absolute inset-0 pt-[42px] pb-[16px] overflow-auto bg-gray-100 select-none [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full flex items-start justify-center"
+            className={`relative overflow-hidden flex-shrink-0 border-r border-gray-200 bg-white ${isMobile ? 'w-full' : ''}`}
+            style={isMobile ? {} : { width: `${leftPct}%` }}
           >
+            <div className="absolute top-0 left-0 right-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
+              <span className="text-[11px] sm:text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
+                Reference Material
+              </span>
+            </div>
             <div
-              style={{
-                position: 'relative',
-                marginTop: '16px',
-                marginBottom: '16px',
-                transformOrigin: 'top center',
-              }}
+              ref={refContainerRef}
+              className="absolute inset-0 pt-[42px] pb-[16px] overflow-auto bg-gray-100 select-none flex items-start justify-center"
             >
-              <img
-                ref={refImgRef}
-                src={currentPage.url}
-                alt="Reference Material"
-                onLoad={onRefImageLoad}
-                draggable={false}
+              <div
                 style={{
-                  display: 'block',
-                  userSelect: 'none',
-                  maxWidth: 'none',
-                  transform: `scale(${refZoom})`,
+                  position: 'relative',
+                  marginTop: '16px',
+                  marginBottom: '16px',
                   transformOrigin: 'top center',
                 }}
-              />
-            </div>
-          </div>
-          {(!currentPage.url) && (
-            <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide">
-              No Reference Loaded
-            </div>
-          )}
-        </div>
-
-        {/* Left divider */}
-        <div
-          className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
-          style={{ width: 8 }}
-          onMouseDown={handleLeftDividerDown}
-        >
-          <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
-          <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
-            {[0, 1, 2].map(i => (
-              <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
-            ))}
-          </div>
-        </div>
-
-        {/* CENTER: Submission Output */}
-        <div
-          className="relative overflow-hidden flex-1 flex flex-col bg-slate-50/30"
-          style={{ minWidth: `${MIN_CENTER_PCT}%` }}
-        >
-          {/* Header */}
-          <div className="flex-shrink-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
-            <span className="text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
-              Submission Output
-            </span>
-            {isStreaming && (
-              <span className="inline-flex items-center gap-[3px] ml-2">
-                {[0, 1, 2].map(i => (
-                  <span key={i} className="w-1 h-1 rounded-full bg-orange-400 animate-bounce" style={{ animationDelay: `${i * 0.15}s` }} />
-                ))}
-              </span>
-            )}
-          </div>
-          
-          {/* Main Working Area */}
-          <div className="relative flex-1 overflow-hidden flex flex-row">
-            {/* Canvas Container */}
-            <div className="relative flex-1 h-full bg-slate-50">
-              <div className="absolute inset-0">
-                <OcrCanvas
-                  imageUrl={currentPage.url}
-                  imageWidth={currentPage.width}
-                  imageHeight={currentPage.height}
-                  annotations={annList}
-                  sessionId={pageKey}
-                  participant={participant}
+              >
+                <img
+                  ref={refImgRef}
+                  src={currentPage.url}
+                  alt="Reference Material"
+                  onLoad={onRefImageLoad}
+                  draggable={false}
+                  style={{
+                    display: 'block',
+                    userSelect: 'none',
+                    maxWidth: 'none',
+                    transform: `scale(${refZoom})`,
+                    transformOrigin: 'top center',
+                  }}
                 />
               </div>
-              {(!currentPage.url) && (
-                <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide bg-gray-50">
-                  No Submission Loaded
-                </div>
+            </div>
+            {(!currentPage.url) && (
+              <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-[10px] uppercase tracking-widest">
+                No Reference Loaded
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Left divider */}
+        {!isMobile && (
+          <div
+            className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
+            style={{ width: 8 }}
+            onMouseDown={handleLeftDividerDown}
+          >
+            <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
+            <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
+              {[0, 1, 2].map(i => (
+                <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(!isMobile || activeTab === 'submission') && (
+          <div
+            className="relative overflow-hidden flex-1 flex flex-col bg-slate-50/30"
+            style={isMobile ? {} : { minWidth: `${MIN_CENTER_PCT}%` }}
+          >
+            {/* Header */}
+            <div className="flex-shrink-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
+              <span className="text-[11px] sm:text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
+                Submission Output
+              </span>
+              {isStreaming && (
+                <span className="inline-flex items-center gap-[3px] ml-2">
+                  {[0, 1, 2].map(i => (
+                    <span key={i} className="w-1 h-1 rounded-full bg-orange-400 animate-bounce" style={{ animationDelay: `${i * 0.15}s` }} />
+                  ))}
+                </span>
               )}
             </div>
+            
+            {/* Main Working Area */}
+            <div className="relative flex-1 overflow-hidden flex flex-col lg:flex-row">
+              {/* Canvas Container */}
+              <div className="relative flex-1 h-full bg-slate-50">
+                <div className="absolute inset-0">
+                  <OcrCanvas
+                    imageUrl={currentPage.url}
+                    imageWidth={currentPage.width}
+                    imageHeight={currentPage.height}
+                    annotations={annList}
+                    sessionId={pageKey}
+                    participant={participant}
+                  />
+                </div>
+                {(!currentPage.url) && (
+                  <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-[10px] uppercase tracking-widest bg-gray-50">
+                    No Submission Loaded
+                  </div>
+                )}
+              </div>
 
-            {/* Vertical Toolkit Sidebar */}
-            <div className="flex-shrink-0 w-[95px] bg-white/95 backdrop-blur-md z-20 flex flex-col pt-4 pb-4 border-l border-gray-200 shadow-[-2px_0_15px_rgba(0,0,0,0.04)] items-center overflow-y-auto [&::-webkit-scrollbar]:w-0">
-              <EduVizErrorToolbar vertical={true} />
+              {/* toolkit position: mobile bottom, desktop right side */}
+              <div className={`${
+                isMobile 
+                  ? 'absolute bottom-4 left-1/2 -translate-x-1/2 z-30 w-auto' 
+                  : 'flex-shrink-0 w-[95px] h-full bg-white/95 backdrop-blur-md z-20 flex flex-col pt-4 pb-4 border-l border-gray-200 shadow-[-2px_0_15px_rgba(0,0,0,0.04)] items-center overflow-y-auto [&::-webkit-scrollbar]:w-0'
+              }`}>
+                <EduVizErrorToolbar vertical={!isMobile} />
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {/* Right divider */}
-        <div
-          className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
-          style={{ width: 8 }}
-          onMouseDown={handleRightDividerDown}
-        >
-          <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
-          <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
-            {[0, 1, 2].map(i => (
-              <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
-            ))}
+        {!isMobile && (
+          <div
+            className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
+            style={{ width: 8 }}
+            onMouseDown={handleRightDividerDown}
+          >
+            <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
+            <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
+              {[0, 1, 2].map(i => (
+                <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
-        {/* RIGHT: Assessment Panel */}
-        <div
-          className="flex-shrink-0 flex flex-col overflow-hidden border-l border-gray-200 bg-white"
-          style={{ width: `${rightPct}%` }}
-        >
-          <div className="flex-1 overflow-hidden relative">
-            <EduVizAssessmentPanel />
+        {(!isMobile || activeTab === 'assessment') && (
+          <div
+            className={`flex-shrink-0 flex flex-col overflow-hidden bg-white ${isMobile ? 'w-full' : 'border-l border-gray-200'}`}
+            style={isMobile ? {} : { width: `${rightPct}%` }}
+          >
+            <div className="flex-1 overflow-hidden relative">
+              <EduVizAssessmentPanel />
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Metadata bar below */}

--- a/src/features/eduviz/components/EduVizDocumentView.jsx
+++ b/src/features/eduviz/components/EduVizDocumentView.jsx
@@ -1,0 +1,293 @@
+import { useRef, useState, useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { OcrCanvas } from '../../ocr/components/OcrCanvas';
+import { EduVizAssessmentPanel } from './EduVizAssessmentPanel';
+import { EduVizErrorToolbar } from './EduVizErrorToolbar';
+import { EduVizMetadataBar } from './EduVizMetadataBar';
+import { setSelectedAnnotationId, setZoomLevel, addAnnotation as eduvizAddAnnotation } from '../store/eduvizSlice';
+import {
+  setAnnotationMessageId as setOcrAnnotationMessageId,
+  setSelectedAnnotationId as setOcrSelectedAnnotationId,
+  setActiveAnnotationId as setOcrActiveAnnotationId,
+} from '../../ocr/store/chatSlice';
+
+const MIN_LEFT_PCT = 20;
+const MAX_LEFT_PCT = 45;
+const MIN_CENTER_PCT = 25;
+
+/**
+ * EduVizDocumentView — three-pane layout:
+ * Left:   REFERENCE MATERIAL (read-only image)
+ * Center: SUBMISSION OUTPUT (image + annotation canvas)
+ * Right:  ASSESSMENT PANEL (rubrics, textareas, submit)
+ * Bottom: Error toolbar + Metadata bar
+ */
+export function EduVizDocumentView({ sessionId }) {
+  const dispatch = useDispatch();
+  const participant = 'modelA';
+
+  const {
+    pages, currentPageIndex, annotations, annotationMessageIds,
+    processingStatus, annotationHistory, annotationFuture, activeSession,
+  } = useSelector(s => s.eduviz);
+
+  const isStreaming = processingStatus === 'streaming';
+  const [leftPct, setLeftPct] = useState(30);
+  const [rightPct, setRightPct] = useState(28);
+  const containerRef = useRef(null);
+  const isDraggingLeft = useRef(false);
+  const isDraggingRight = useRef(false);
+  const refImgRef = useRef(null);
+  const refContainerRef = useRef(null);
+  const [refZoom, setRefZoom] = useState(1.0);
+
+  const currentPage = pages[currentPageIndex];
+  const pageKey = `${sessionId}_${currentPageIndex}`;
+  const sessionAnnotations = annotations[pageKey] || annotations[sessionId] || { modelA: [] };
+  const annList = sessionAnnotations[participant] || [];
+
+  // Read ocrChat annotations to detect new boxes drawn via useBoxEditor
+  const ocrAnnotations = useSelector(s => s.ocrChat.annotations[pageKey]?.modelA || []);
+  const prevOcrCountRef = useRef(0);
+  const syncedToOcrRef = useRef(new Set());
+
+  // Sync eduviz annotations → ocrChat store (so OcrCanvas can render them)
+  useEffect(() => {
+    annList.forEach(ann => {
+      if (!syncedToOcrRef.current.has(ann.id)) {
+        dispatch({ type: 'ocrChat/streamAnnotation', payload: { sessionId: pageKey, participant, annotation: ann } });
+        syncedToOcrRef.current.add(ann.id);
+      }
+    });
+  }, [annList, pageKey, participant, dispatch]);
+
+  // Sync: when OcrCanvas adds a new annotation via useBoxEditor (which writes to ocrChat),
+  // mirror it into eduviz store
+  useEffect(() => {
+    if (ocrAnnotations.length > prevOcrCountRef.current && prevOcrCountRef.current > 0) {
+      // New annotations were added by useBoxEditor to ocrChat
+      const newOnes = ocrAnnotations.slice(prevOcrCountRef.current);
+      newOnes.forEach(ann => {
+        // Check if it already exists in eduviz
+        const exists = annList.find(a => a.id === ann.id);
+        if (!exists) {
+          dispatch(eduvizAddAnnotation({ sessionId: pageKey, participant, annotation: ann }));
+        }
+      });
+    }
+    prevOcrCountRef.current = ocrAnnotations.length;
+  }, [ocrAnnotations.length]);
+
+  // Sync: keep eduviz.selectedAnnotationId matched to ocrChat.selectedAnnotationId (canvas clicks)
+  const ocrSelectedId = useSelector(s => s.ocrChat.selectedAnnotationId);
+  const eduvizSelectedId = useSelector(s => s.eduviz.selectedAnnotationId);
+  useEffect(() => {
+    if (ocrSelectedId && ocrSelectedId !== eduvizSelectedId) {
+      dispatch(setSelectedAnnotationId(ocrSelectedId));
+    }
+  }, [ocrSelectedId, eduvizSelectedId, dispatch]);
+
+  // Auto-select first annotation when annotations load
+  useEffect(() => {
+    if (annList.length > 0 && !ocrSelectedId) {
+      dispatch(setSelectedAnnotationId(annList[0].id));
+      dispatch(setOcrSelectedAnnotationId(annList[0].id));
+    }
+  }, [annList.length > 0, ocrSelectedId, dispatch]);
+
+  // Fit reference image to container
+  const onRefImageLoad = useCallback(() => {
+    const img = refImgRef.current;
+    const container = refContainerRef.current;
+    if (!img || !container) return;
+    const pad = 32;
+    const fitZoom = Math.min(
+      (container.clientWidth - pad) / img.naturalWidth,
+      (container.clientHeight - pad) / img.naturalHeight,
+      1.0
+    );
+    setRefZoom(Math.max(0.1, Math.round(fitZoom * 100) / 100));
+  }, []);
+
+  // Ctrl+scroll zoom for reference pane
+  useEffect(() => {
+    const container = refContainerRef.current;
+    if (!container) return;
+    const onWheel = (e) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? 1.08 : 1 / 1.08;
+      setRefZoom(z => Math.min(3.0, Math.max(0.1, z * factor)));
+    };
+    container.addEventListener('wheel', onWheel, { passive: false });
+    return () => container.removeEventListener('wheel', onWheel);
+  }, []);
+
+  // Left divider drag
+  const handleLeftDividerDown = useCallback((e) => {
+    e.preventDefault();
+    isDraggingLeft.current = true;
+    const onMouseMove = (e) => {
+      if (!isDraggingLeft.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      setLeftPct(Math.min(MAX_LEFT_PCT, Math.max(MIN_LEFT_PCT, pct)));
+    };
+    const onMouseUp = () => {
+      isDraggingLeft.current = false;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, []);
+
+  // Right divider drag
+  const handleRightDividerDown = useCallback((e) => {
+    e.preventDefault();
+    isDraggingRight.current = true;
+    const onMouseMove = (e) => {
+      if (!isDraggingRight.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const pctFromRight = ((rect.right - e.clientX) / rect.width) * 100;
+      setRightPct(Math.min(40, Math.max(20, pctFromRight)));
+    };
+    const onMouseUp = () => {
+      isDraggingRight.current = false;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, []);
+
+  if (!currentPage) return null;
+
+  const centerPct = Math.max(MIN_CENTER_PCT, 100 - leftPct - rightPct);
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+
+      {/* Three panes */}
+      <div ref={containerRef} className="flex flex-1 overflow-hidden">
+
+        {/* LEFT: Reference Material */}
+        <div
+          className="relative overflow-hidden flex-shrink-0 border-r border-gray-200"
+          style={{ width: `${leftPct}%` }}
+        >
+          <div className="absolute top-0 left-0 right-0 z-10 px-3 py-1.5 bg-white/90 backdrop-blur-sm border-b border-gray-100">
+            <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Reference Material</span>
+          </div>
+          <div
+            ref={refContainerRef}
+            className="absolute inset-0 pt-8 overflow-auto bg-gray-100 select-none [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full"
+          >
+            <div
+              style={{
+                position: 'relative',
+                margin: '16px auto',
+                transformOrigin: 'top left',
+              }}
+            >
+              <img
+                ref={refImgRef}
+                src={currentPage.url}
+                alt="Reference Material"
+                onLoad={onRefImageLoad}
+                draggable={false}
+                style={{
+                  display: 'block',
+                  userSelect: 'none',
+                  maxWidth: 'none',
+                  transform: `scale(${refZoom})`,
+                  transformOrigin: 'top left',
+                }}
+              />
+            </div>
+          </div>
+          {(!currentPage.url) && (
+            <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide">
+              No Reference Loaded
+            </div>
+          )}
+        </div>
+
+        {/* Left divider */}
+        <div
+          className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
+          style={{ width: 8 }}
+          onMouseDown={handleLeftDividerDown}
+        >
+          <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
+          <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
+            {[0, 1, 2].map(i => (
+              <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
+            ))}
+          </div>
+        </div>
+
+        {/* CENTER: Submission Output */}
+        <div
+          className="relative overflow-hidden flex-1"
+          style={{ minWidth: `${MIN_CENTER_PCT}%` }}
+        >
+          <div className="absolute top-0 left-0 right-0 z-10 px-3 py-1.5 bg-white/90 backdrop-blur-sm border-b border-gray-100">
+            <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Submission Output</span>
+            {isStreaming && (
+              <span className="inline-flex items-center gap-[3px] ml-2">
+                {[0, 1, 2].map(i => (
+                  <span key={i} className="w-1 h-1 rounded-full bg-orange-400 animate-bounce" style={{ animationDelay: `${i * 0.15}s` }} />
+                ))}
+              </span>
+            )}
+          </div>
+          <div className="absolute inset-0 pt-8">
+            <OcrCanvas
+              imageUrl={currentPage.url}
+              imageWidth={currentPage.width}
+              imageHeight={currentPage.height}
+              annotations={annList}
+              sessionId={pageKey}
+              participant={participant}
+            />
+          </div>
+          {/* Floating error toolbar */}
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 pointer-events-auto">
+            <EduVizErrorToolbar />
+          </div>
+          {(!currentPage.url) && (
+            <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide">
+              No Submission Loaded
+            </div>
+          )}
+        </div>
+
+        {/* Right divider */}
+        <div
+          className="group relative flex-shrink-0 flex items-center justify-center cursor-col-resize select-none"
+          style={{ width: 8 }}
+          onMouseDown={handleRightDividerDown}
+        >
+          <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-gray-300 group-hover:bg-orange-400 transition-colors duration-150" />
+          <div className="relative z-10 flex flex-col gap-[3px] px-0.5 py-1.5 rounded-full bg-white border border-gray-200 shadow-sm group-hover:border-orange-300 transition-all duration-150">
+            {[0, 1, 2].map(i => (
+              <div key={i} className="w-[3px] h-[3px] rounded-full bg-gray-400 group-hover:bg-orange-500 transition-colors duration-150" />
+            ))}
+          </div>
+        </div>
+
+        {/* RIGHT: Assessment Panel */}
+        <div
+          className="flex-shrink-0 overflow-hidden border-l border-gray-200"
+          style={{ width: `${rightPct}%` }}
+        >
+          <EduVizAssessmentPanel />
+        </div>
+      </div>
+
+      {/* Metadata bar below */}
+      <EduVizMetadataBar />
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizDocumentView.jsx
+++ b/src/features/eduviz/components/EduVizDocumentView.jsx
@@ -29,7 +29,10 @@ export function EduVizDocumentView({ sessionId }) {
   const {
     pages, currentPageIndex, annotations, annotationMessageIds,
     processingStatus, annotationHistory, annotationFuture, activeSession,
+    zoomLevel,
   } = useSelector(s => s.eduviz);
+
+  const prevZoomValRef = useRef(zoomLevel);
 
   const isStreaming = processingStatus === 'streaming';
   const [leftPct, setLeftPct] = useState(30);
@@ -176,18 +179,21 @@ export function EduVizDocumentView({ sessionId }) {
           className="relative overflow-hidden flex-shrink-0 border-r border-gray-200"
           style={{ width: `${leftPct}%` }}
         >
-          <div className="absolute top-0 left-0 right-0 z-10 px-3 py-1.5 bg-white/90 backdrop-blur-sm border-b border-gray-100">
-            <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Reference Material</span>
+          <div className="absolute top-0 left-0 right-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
+            <span className="text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
+              Reference Material
+            </span>
           </div>
           <div
             ref={refContainerRef}
-            className="absolute inset-0 pt-8 overflow-auto bg-gray-100 select-none [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full"
+            className="absolute inset-0 pt-[42px] pb-[16px] overflow-auto bg-gray-100 select-none [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full flex items-start justify-center"
           >
             <div
               style={{
                 position: 'relative',
-                margin: '16px auto',
-                transformOrigin: 'top left',
+                marginTop: '16px',
+                marginBottom: '16px',
+                transformOrigin: 'top center',
               }}
             >
               <img
@@ -201,7 +207,7 @@ export function EduVizDocumentView({ sessionId }) {
                   userSelect: 'none',
                   maxWidth: 'none',
                   transform: `scale(${refZoom})`,
-                  transformOrigin: 'top left',
+                  transformOrigin: 'top center',
                 }}
               />
             </div>
@@ -229,11 +235,14 @@ export function EduVizDocumentView({ sessionId }) {
 
         {/* CENTER: Submission Output */}
         <div
-          className="relative overflow-hidden flex-1"
+          className="relative overflow-hidden flex-1 flex flex-col bg-slate-50/30"
           style={{ minWidth: `${MIN_CENTER_PCT}%` }}
         >
-          <div className="absolute top-0 left-0 right-0 z-10 px-3 py-1.5 bg-white/90 backdrop-blur-sm border-b border-gray-100">
-            <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Submission Output</span>
+          {/* Header */}
+          <div className="flex-shrink-0 z-20 px-4 py-2.5 bg-white/90 backdrop-blur-md shadow-[0_1px_8px_rgba(0,0,0,0.03)] border-b border-gray-100 flex items-center">
+            <span className="text-[11.5px] font-bold text-gray-700 uppercase tracking-widest px-1 relative after:absolute after:-bottom-2.5 after:left-1 after:w-[80%] after:h-[2px] after:bg-orange-400 after:rounded-t-full">
+              Submission Output
+            </span>
             {isStreaming && (
               <span className="inline-flex items-center gap-[3px] ml-2">
                 {[0, 1, 2].map(i => (
@@ -242,25 +251,33 @@ export function EduVizDocumentView({ sessionId }) {
               </span>
             )}
           </div>
-          <div className="absolute inset-0 pt-8">
-            <OcrCanvas
-              imageUrl={currentPage.url}
-              imageWidth={currentPage.width}
-              imageHeight={currentPage.height}
-              annotations={annList}
-              sessionId={pageKey}
-              participant={participant}
-            />
-          </div>
-          {/* Floating error toolbar */}
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 pointer-events-auto">
-            <EduVizErrorToolbar />
-          </div>
-          {(!currentPage.url) && (
-            <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide">
-              No Submission Loaded
+          
+          {/* Main Working Area */}
+          <div className="relative flex-1 overflow-hidden flex flex-row">
+            {/* Canvas Container */}
+            <div className="relative flex-1 h-full bg-slate-50">
+              <div className="absolute inset-0">
+                <OcrCanvas
+                  imageUrl={currentPage.url}
+                  imageWidth={currentPage.width}
+                  imageHeight={currentPage.height}
+                  annotations={annList}
+                  sessionId={pageKey}
+                  participant={participant}
+                />
+              </div>
+              {(!currentPage.url) && (
+                <div className="absolute inset-0 flex items-center justify-center text-gray-400 text-sm uppercase tracking-wide bg-gray-50">
+                  No Submission Loaded
+                </div>
+              )}
             </div>
-          )}
+
+            {/* Vertical Toolkit Sidebar */}
+            <div className="flex-shrink-0 w-[95px] bg-white/95 backdrop-blur-md z-20 flex flex-col pt-4 pb-4 border-l border-gray-200 shadow-[-2px_0_15px_rgba(0,0,0,0.04)] items-center overflow-y-auto [&::-webkit-scrollbar]:w-0">
+              <EduVizErrorToolbar vertical={true} />
+            </div>
+          </div>
         </div>
 
         {/* Right divider */}
@@ -279,10 +296,12 @@ export function EduVizDocumentView({ sessionId }) {
 
         {/* RIGHT: Assessment Panel */}
         <div
-          className="flex-shrink-0 overflow-hidden border-l border-gray-200"
+          className="flex-shrink-0 flex flex-col overflow-hidden border-l border-gray-200 bg-white"
           style={{ width: `${rightPct}%` }}
         >
-          <EduVizAssessmentPanel />
+          <div className="flex-1 overflow-hidden relative">
+            <EduVizAssessmentPanel />
+          </div>
         </div>
       </div>
 

--- a/src/features/eduviz/components/EduVizErrorToolbar.jsx
+++ b/src/features/eduviz/components/EduVizErrorToolbar.jsx
@@ -1,0 +1,128 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { MousePointer2, Pencil, ZoomIn, ZoomOut } from 'lucide-react';
+import { setCanvasMode, setDrawType, setZoomLevel } from '../store/eduvizSlice';
+import {
+  setCanvasMode as setOcrCanvasMode,
+  setDrawType as setOcrDrawType,
+  setZoomLevel as setOcrZoomLevel,
+} from '../../ocr/store/chatSlice';
+import { EDUVIZ_TYPE_OPTIONS, EDUVIZ_TYPE_COLORS } from '../utils/eduvizTypeColors';
+
+export function EduVizErrorToolbar() {
+  const dispatch = useDispatch();
+  const { zoomLevel, canvasMode, drawType } = useSelector(s => s.eduviz);
+
+  const zoomPercent = Math.round(zoomLevel * 100);
+  const handleZoomIn  = () => {
+    const z = Math.min(3.0, zoomLevel + 0.15);
+    dispatch(setZoomLevel(z));
+    dispatch(setOcrZoomLevel(z));
+  };
+  const handleZoomOut = () => {
+    const z = Math.max(0.1, zoomLevel - 0.15);
+    dispatch(setZoomLevel(z));
+    dispatch(setOcrZoomLevel(z));
+  };
+
+  const dispatchMode = (mode) => {
+    dispatch(setCanvasMode(mode));
+    dispatch(setOcrCanvasMode(mode));
+  };
+
+  const dispatchDrawType = (type) => {
+    dispatch(setDrawType(type));
+    dispatch(setOcrDrawType(type));
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 px-3 py-2 rounded-2xl bg-white/95 backdrop-blur-sm shadow-lg border border-gray-200/60 text-xs flex-nowrap">
+
+      {/* Mode toggle */}
+      <div className="flex items-center bg-gray-100 rounded-xl p-0.5">
+        <button
+          title="Select / Move / Resize"
+          onClick={() => dispatchMode('select')}
+          className={`flex items-center gap-1.5 px-3 py-1 rounded-[10px] font-medium transition-all duration-150 ${
+            canvasMode === 'select'
+              ? 'bg-white text-gray-800 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          <MousePointer2 size={12} />
+          Select
+        </button>
+        <button
+          title="Draw error box"
+          onClick={() => dispatchMode('draw')}
+          className={`flex items-center gap-1.5 px-3 py-1 rounded-[10px] font-medium transition-all duration-150 ${
+            canvasMode === 'draw'
+              ? 'bg-white text-orange-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          <Pencil size={12} />
+          Draw
+        </button>
+      </div>
+
+      <div className="w-px h-5 bg-gray-200 mx-0.5" />
+
+      {/* Error type labels */}
+      <div className="flex items-center gap-1">
+        {EDUVIZ_TYPE_OPTIONS.map(opt => {
+          const isActive = drawType === opt.value;
+          const color = EDUVIZ_TYPE_COLORS[opt.value];
+          return (
+            <button
+              key={opt.value}
+              title={opt.label}
+              onClick={() => {
+                dispatchDrawType(opt.value);
+                if (canvasMode !== 'draw') dispatchMode('draw');
+              }}
+              className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg font-medium transition-all duration-150 border ${
+                isActive
+                  ? 'shadow-sm'
+                  : 'border-transparent text-gray-500 hover:bg-gray-50'
+              }`}
+              style={isActive ? {
+                backgroundColor: color + '15',
+                borderColor: color + '40',
+                color: color,
+              } : {}}
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: color }}
+              />
+              <span className="hidden sm:inline">{opt.label.replace(' Error', '')}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="w-px h-5 bg-gray-200 mx-0.5" />
+
+      {/* Zoom */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={handleZoomOut}
+          disabled={zoomLevel <= 0.1}
+          className="w-6 h-6 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500 disabled:opacity-35 transition-colors"
+        >
+          <ZoomOut size={14} />
+        </button>
+        <span className="tabular-nums w-10 text-center text-gray-700 font-medium">
+          {zoomPercent}%
+        </span>
+        <button
+          onClick={handleZoomIn}
+          disabled={zoomLevel >= 3.0}
+          className="w-6 h-6 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500 disabled:opacity-35 transition-colors"
+        >
+          <ZoomIn size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizErrorToolbar.jsx
+++ b/src/features/eduviz/components/EduVizErrorToolbar.jsx
@@ -75,7 +75,7 @@ export function EduVizErrorToolbar({ vertical = false }) {
   };
 
   return (
-    <div className={`flex ${vertical ? 'flex-col items-center w-full gap-4 pb-4' : 'items-center gap-1.5 px-3 py-2 rounded-2xl bg-white/95 backdrop-blur-sm shadow-lg border border-gray-200/60 text-xs flex-nowrap'}`}>
+    <div className={`flex ${vertical ? 'flex-col items-center w-full gap-4 pb-4' : 'items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 rounded-2xl bg-white/98 backdrop-blur-md shadow-xl border border-gray-200/80 text-[10px] sm:text-xs flex-nowrap overflow-x-auto [&::-webkit-scrollbar]:h-0'}`}>
 
       {/* Mode toggle (Top) */}
       <div className={`flex ${vertical ? 'flex-col w-full' : 'items-center'} bg-gray-100/80 rounded-xl p-1 gap-1`}>
@@ -130,10 +130,10 @@ export function EduVizErrorToolbar({ vertical = false }) {
                   if (canvasMode !== 'draw') dispatchMode('draw');
                 }
               }}
-              className={`flex ${vertical ? 'flex-col gap-1 w-full py-1.5 items-center' : 'items-center justify-center gap-1 px-2.5 py-1.5'} rounded-xl font-medium transition-all duration-150 border ${
+              className={`flex ${vertical ? 'flex-col gap-1 w-full py-1.5 items-center' : 'items-center justify-center gap-1.5 px-2 sm:px-3 py-1.5'} rounded-xl font-medium transition-all duration-150 border ${
                 isActive
                   ? 'shadow-sm shadow-black/5 ring-1 ring-black/5'
-                  : 'border-transparent text-gray-500 hover:bg-gray-100'
+                  : 'border-transparent text-gray-700 hover:bg-gray-100'
               }`}
               style={isActive ? {
                 backgroundColor: color + '12',

--- a/src/features/eduviz/components/EduVizErrorToolbar.jsx
+++ b/src/features/eduviz/components/EduVizErrorToolbar.jsx
@@ -1,6 +1,7 @@
+import { useRef, useEffect, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { MousePointer2, Pencil, ZoomIn, ZoomOut } from 'lucide-react';
-import { setCanvasMode, setDrawType, setZoomLevel } from '../store/eduvizSlice';
+import { setCanvasMode, setDrawType, setZoomLevel, updateAnnotationType, toggleAnnotationLabel } from '../store/eduvizSlice';
 import {
   setCanvasMode as setOcrCanvasMode,
   setDrawType as setOcrDrawType,
@@ -8,9 +9,12 @@ import {
 } from '../../ocr/store/chatSlice';
 import { EDUVIZ_TYPE_OPTIONS, EDUVIZ_TYPE_COLORS } from '../utils/eduvizTypeColors';
 
-export function EduVizErrorToolbar() {
+export function EduVizErrorToolbar({ vertical = false }) {
   const dispatch = useDispatch();
-  const { zoomLevel, canvasMode, drawType } = useSelector(s => s.eduviz);
+  const { zoomLevel, canvasMode, drawType, selectedAnnotationId, activeSession, currentPageIndex, editedAnnotations } = useSelector(s => s.eduviz);
+  const pageKey = activeSession ? `${activeSession.id}_${currentPageIndex}` : null;
+  const participant = 'modelA';
+  const selectedAnn = (selectedAnnotationId && pageKey) ? editedAnnotations[pageKey]?.[participant]?.[selectedAnnotationId] : null;
 
   const zoomPercent = Math.round(zoomLevel * 100);
   const handleZoomIn  = () => {
@@ -34,93 +38,175 @@ export function EduVizErrorToolbar() {
     dispatch(setOcrDrawType(type));
   };
 
-  return (
-    <div className="flex items-center gap-1.5 px-3 py-2 rounded-2xl bg-white/95 backdrop-blur-sm shadow-lg border border-gray-200/60 text-xs flex-nowrap">
+  const [inputVal, setInputVal] = useState(zoomPercent.toString());
+  const [isEditing, setIsEditing] = useState(false);
+  const [showPresets, setShowPresets] = useState(false);
 
-      {/* Mode toggle */}
-      <div className="flex items-center bg-gray-100 rounded-xl p-0.5">
+  const ZOOM_PRESETS = [50, 75, 90, 100, 125, 150, 200];
+
+  // Sync internal input value with Redux zoomPercent when NOT typing
+  useEffect(() => {
+    if (!isEditing) {
+      setInputVal(zoomPercent.toString());
+    }
+  }, [zoomPercent, isEditing]);
+
+  const commitZoom = (val) => {
+    let numeric = parseInt(val.replace('%', ''), 10);
+    if (isNaN(numeric)) return;
+    // Clamp between 10% and 300%
+    numeric = Math.max(10, Math.min(300, numeric));
+    const newLevel = numeric / 100;
+    dispatch(setZoomLevel(newLevel));
+    dispatch(setOcrZoomLevel(newLevel));
+    setInputVal(numeric.toString());
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      commitZoom(inputVal);
+      e.currentTarget.blur();
+    } else if (e.key === 'Escape') {
+      setInputVal(zoomPercent.toString());
+      setIsEditing(false);
+      e.currentTarget.blur();
+    }
+  };
+
+  return (
+    <div className={`flex ${vertical ? 'flex-col items-center w-full gap-4 pb-4' : 'items-center gap-1.5 px-3 py-2 rounded-2xl bg-white/95 backdrop-blur-sm shadow-lg border border-gray-200/60 text-xs flex-nowrap'}`}>
+
+      {/* Mode toggle (Top) */}
+      <div className={`flex ${vertical ? 'flex-col w-full' : 'items-center'} bg-gray-100/80 rounded-xl p-1 gap-1`}>
         <button
           title="Select / Move / Resize"
           onClick={() => dispatchMode('select')}
-          className={`flex items-center gap-1.5 px-3 py-1 rounded-[10px] font-medium transition-all duration-150 ${
+          className={`flex ${vertical ? 'flex-col items-center py-2.5 w-full gap-1.5' : 'items-center gap-1.5 px-3 py-1'} justify-center rounded-[10px] font-medium transition-all duration-150 ${
             canvasMode === 'select'
               ? 'bg-white text-gray-800 shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'
+              : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200/50'
           }`}
         >
-          <MousePointer2 size={12} />
-          Select
+          <MousePointer2 size={vertical ? 16 : 12} />
+          <span className={vertical ? 'text-[8.5px] uppercase tracking-widest font-bold opacity-80 leading-none' : ''}>Select</span>
         </button>
         <button
           title="Draw error box"
           onClick={() => dispatchMode('draw')}
-          className={`flex items-center gap-1.5 px-3 py-1 rounded-[10px] font-medium transition-all duration-150 ${
+          className={`flex ${vertical ? 'flex-col items-center py-2.5 w-full gap-1.5' : 'items-center gap-1.5 px-3 py-1'} justify-center rounded-[10px] font-medium transition-all duration-150 ${
             canvasMode === 'draw'
               ? 'bg-white text-orange-600 shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'
+              : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200/50'
           }`}
         >
-          <Pencil size={12} />
-          Draw
+          <Pencil size={vertical ? 16 : 12} />
+          <span className={vertical ? 'text-[8.5px] uppercase tracking-widest font-bold opacity-80 leading-none' : ''}>Draw</span>
         </button>
       </div>
 
-      <div className="w-px h-5 bg-gray-200 mx-0.5" />
+      <div className={`${vertical ? 'w-8 h-px' : 'w-px h-5'} bg-gray-200/80 my-0.5`} />
 
       {/* Error type labels */}
-      <div className="flex items-center gap-1">
+      <div className={`flex ${vertical ? 'flex-col gap-2 w-full' : 'items-center gap-1.5'}`}>
         {EDUVIZ_TYPE_OPTIONS.map(opt => {
-          const isActive = drawType === opt.value;
+          const isSelectedActive = selectedAnn?.labels?.includes(opt.value) || (!selectedAnn?.labels && selectedAnn?.type === opt.value);
+          const isActive = selectedAnn ? isSelectedActive : drawType === opt.value;
           const color = EDUVIZ_TYPE_COLORS[opt.value];
           return (
             <button
               key={opt.value}
               title={opt.label}
               onClick={() => {
-                dispatchDrawType(opt.value);
-                if (canvasMode !== 'draw') dispatchMode('draw');
+                if (selectedAnnotationId && pageKey) {
+                  dispatch(toggleAnnotationLabel({
+                    sessionId: pageKey,
+                    participant,
+                    annotationId: selectedAnnotationId,
+                    label: opt.value
+                  }));
+                } else {
+                  dispatchDrawType(opt.value);
+                  if (canvasMode !== 'draw') dispatchMode('draw');
+                }
               }}
-              className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg font-medium transition-all duration-150 border ${
+              className={`flex ${vertical ? 'flex-col gap-1 w-full py-1.5 items-center' : 'items-center justify-center gap-1 px-2.5 py-1.5'} rounded-xl font-medium transition-all duration-150 border ${
                 isActive
-                  ? 'shadow-sm'
-                  : 'border-transparent text-gray-500 hover:bg-gray-50'
+                  ? 'shadow-sm shadow-black/5 ring-1 ring-black/5'
+                  : 'border-transparent text-gray-500 hover:bg-gray-100'
               }`}
               style={isActive ? {
-                backgroundColor: color + '15',
+                backgroundColor: color + '12',
                 borderColor: color + '40',
                 color: color,
               } : {}}
             >
               <span
-                className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                className={`${vertical ? 'w-[12px] h-[12px]' : 'w-2.5 h-2.5'} rounded-full flex-shrink-0 shadow-sm`}
                 style={{ backgroundColor: color }}
               />
-              <span className="hidden sm:inline">{opt.label.replace(' Error', '')}</span>
+              <span className={vertical ? 'text-[8.5px] uppercase tracking-wider font-bold leading-tight text-center opacity-[0.85] max-w-[75px] truncate' : 'hidden sm:inline'}>
+                 {opt.label.replace(' Error', '')}
+              </span>
             </button>
           );
         })}
       </div>
 
-      <div className="w-px h-5 bg-gray-200 mx-0.5" />
+      <div className={`${vertical ? 'w-8 h-px' : 'w-px h-5'} bg-gray-200/80 my-0.5`} />
 
       {/* Zoom */}
-      <div className="flex items-center gap-0.5">
-        <button
-          onClick={handleZoomOut}
-          disabled={zoomLevel <= 0.1}
-          className="w-6 h-6 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500 disabled:opacity-35 transition-colors"
-        >
-          <ZoomOut size={14} />
-        </button>
-        <span className="tabular-nums w-10 text-center text-gray-700 font-medium">
-          {zoomPercent}%
-        </span>
+      <div className={`flex ${vertical ? 'flex-col' : 'items-center'} gap-1 bg-gray-50/80 rounded-xl p-1`}>
         <button
           onClick={handleZoomIn}
           disabled={zoomLevel >= 3.0}
-          className="w-6 h-6 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500 disabled:opacity-35 transition-colors"
+          className={`flex items-center justify-center rounded-[10px] hover:bg-white hover:shadow-sm text-gray-600 disabled:opacity-35 transition-all ${vertical ? 'w-7 h-7' : 'w-6 h-6'}`}
         >
-          <ZoomIn size={14} />
+          <ZoomIn size={vertical ? 16 : 14} />
+        </button>
+        <div className={`relative flex items-center justify-center ${vertical ? 'w-full' : 'w-11'}`}>
+          <input
+            type="text"
+            value={isEditing ? inputVal : `${zoomPercent}%`}
+            onFocus={() => {
+              setIsEditing(true);
+              setShowPresets(true);
+              setInputVal(zoomPercent.toString());
+            }}
+            onChange={(e) => setInputVal(e.target.value)}
+            onBlur={() => {
+              // Delay slightly to allow preset clicks
+              setTimeout(() => {
+                commitZoom(inputVal);
+                setShowPresets(false);
+              }, 150);
+            }}
+            onKeyDown={handleKeyDown}
+            className={`w-full bg-transparent text-center text-[10px] text-gray-500 font-bold outline-none tabular-nums hover:text-gray-900 focus:text-orange-600 transition-colors ${vertical ? 'py-1' : ''}`}
+          />
+          {showPresets && (
+            <div className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 bg-white/95 backdrop-blur-md rounded-xl shadow-[0_8px_30px_rgb(0,0,0,0.12)] border border-gray-100 py-1.5 min-w-[80px] overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150" style={{ bottom: 'auto' }}>
+              {ZOOM_PRESETS.map(preset => (
+                <button
+                  key={preset.toString()}
+                  onMouseDown={(e) => {
+                    e.preventDefault(); // Prevent blur before click
+                    commitZoom(preset.toString());
+                  }}
+                  className="w-full text-center px-4 py-1.5 text-[10px] font-bold text-gray-500 hover:bg-orange-50 hover:text-orange-600 transition-colors border-none"
+                >
+                  {preset}%
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={handleZoomOut}
+          disabled={zoomLevel <= 0.25}
+          className={`flex items-center justify-center rounded-[10px] hover:bg-white hover:shadow-sm text-gray-600 disabled:opacity-35 transition-all ${vertical ? 'w-7 h-7' : 'w-6 h-6'}`}
+        >
+          <ZoomOut size={vertical ? 16 : 14} />
         </button>
       </div>
     </div>

--- a/src/features/eduviz/components/EduVizLayout.jsx
+++ b/src/features/eduviz/components/EduVizLayout.jsx
@@ -1,0 +1,384 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Plus, LogOut, User, LogIn, BotMessageSquare,
+  PanelLeftOpen, PanelLeftClose, ChevronDown, ScanText,
+  Pin, Edit2, Ellipsis, Trash2, Search, X,
+  MessageSquare, Mic, Volume2,
+} from 'lucide-react';
+import { AuthModal } from '../../auth/components/AuthModal';
+import { SidebarItem } from '../../ocr/components/SidebarItem';
+import { RenameSessionModal } from '../../chat/components/RenameSessionModal';
+import { DropdownPortal } from '../../../shared/components/DropdownPortal';
+import { useTenant } from '../../../shared/context/TenantContext';
+import { ProviderIcons } from '../../../shared/icons';
+import { logout } from '../../auth/store/authSlice';
+import {
+  fetchEduvizSessions,
+  setActiveSession,
+  clearEduvizState,
+  togglePinEduvizSession,
+  renameEduvizSession,
+  deleteEduvizSession,
+  fetchEduvizSessionById,
+} from '../store/eduvizSlice';
+import { EduVizWindow } from './EduVizWindow';
+import { EduVizModelSelector } from './EduVizModelSelector';
+import useDocumentTitle from '../../../shared/hooks/useDocumentTitle';
+
+/* -------------------------------------------------------------------------- */
+/*  Session item                                                              */
+/* -------------------------------------------------------------------------- */
+const SessionItem = ({ session, isActive, onClick, onPin, onRename, onDelete }) => {
+  const [showMenu, setShowMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(session.title || '');
+  const menuRef = useRef(null);
+  const buttonRef = useRef(null);
+  const inputRef = useRef(null);
+  const dispatch = useDispatch();
+
+  useEffect(() => { setRenameValue(session.title || ''); }, [session.title]);
+  useEffect(() => { if (isRenaming && inputRef.current) inputRef.current.focus(); }, [isRenaming]);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target) &&
+          buttonRef.current && !buttonRef.current.contains(e.target)) setShowMenu(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showMenu]);
+
+  const handleMenuClick = (e) => {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    setMenuPosition({ top: rect.top, left: rect.right + 5 });
+    setShowMenu(!showMenu);
+  };
+
+  const saveRename = () => {
+    if (!renameValue.trim() || renameValue === session.title) {
+      setIsRenaming(false);
+      return;
+    }
+    dispatch(renameEduvizSession({ sessionId: session.id, title: renameValue }));
+    setIsRenaming(false);
+  };
+
+  const firstWord = (session.model_a_name || '').split(/[\s-_]/)[0].toLowerCase();
+  const IconComponent = ProviderIcons[firstWord];
+
+  return (
+    <div className={`group relative flex items-center mb-1 rounded-lg transition-colors select-none ${
+      isActive ? 'bg-orange-100 text-orange-800' : 'text-gray-700 hover:bg-gray-100'
+    }`}>
+      <div onClick={() => !isRenaming && onClick()} className="relative w-full text-left p-2.5 rounded-lg flex items-center gap-3 text-sm font-medium cursor-pointer">
+        <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '28px' }}>
+          {IconComponent ? <IconComponent className="h-4 w-4 rounded-full" /> : <ScanText className="flex-shrink-0" size={16} />}
+        </div>
+        <div className="flex-1 min-w-0">
+          {isRenaming ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') saveRename(); else if (e.key === 'Escape') setIsRenaming(false); }}
+              onBlur={saveRename}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full bg-white border border-orange-300 rounded px-1 py-0.5 text-sm focus:outline-none text-gray-800"
+              autoFocus
+            />
+          ) : (
+            <div className="truncate">{session.title || 'EduViz Session'}</div>
+          )}
+        </div>
+      </div>
+
+      {!isRenaming && (
+        <button
+          ref={buttonRef}
+          onClick={handleMenuClick}
+          className={`hidden md:block absolute right-1 top-1/2 -translate-y-1/2 z-10 p-1 rounded-md hover:bg-gray-200/50 transition-all ${
+            showMenu ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }`}
+        >
+          <Ellipsis size={16} />
+        </button>
+      )}
+
+      {showMenu && (
+        <DropdownPortal>
+          <div ref={menuRef} style={{ position: 'fixed', top: menuPosition.top, left: menuPosition.left }}
+            className="z-[9999] w-48 bg-white rounded-lg shadow-xl border border-gray-100 py-1">
+            <button onClick={(e) => { e.stopPropagation(); onPin(session); setShowMenu(false); }}
+              className="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 flex items-center gap-2">
+              <Pin size={14} className={session.is_pinned ? 'fill-gray-700' : ''} />
+              {session.is_pinned ? 'Unpin' : 'Pin'}
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); setShowMenu(false); setIsRenaming(true); }}
+              className="w-full text-left px-4 py-2 text-sm hover:bg-gray-50 flex items-center gap-2">
+              <Edit2 size={14} /> Rename
+            </button>
+            <button onClick={(e) => { e.stopPropagation(); setShowMenu(false); if (window.confirm('Delete?')) onDelete(session.id); }}
+              className="w-full text-left px-4 py-2 text-sm hover:bg-red-50 flex items-center gap-2 text-red-600">
+              <Trash2 size={14} /> Delete
+            </button>
+          </div>
+        </DropdownPortal>
+      )}
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Layout                                                                    */
+/* -------------------------------------------------------------------------- */
+export function EduVizLayout() {
+  const { sessionId } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { activeSession, sessions } = useSelector(s => s.eduviz);
+  const { user, isAnonymous } = useSelector(s => s.auth);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const { tenant: urlTenant } = useParams();
+  const { tenant: contextTenant } = useTenant();
+  const currentTenant = urlTenant || contextTenant;
+
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [isArenaSwitcherOpen, setIsArenaSwitcherOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+
+  const arenaOptions = [
+    { key: 'LLM', name: 'LLM Arena', icon: MessageSquare, url: '/chat' },
+    { key: 'ASR', name: 'ASR Arena', icon: Mic, url: '/asr' },
+    { key: 'TTS', name: 'TTS Arena', icon: Volume2, url: '/tts' },
+    { key: 'OCR', name: 'OCR Arena', icon: ScanText, url: '/ocr' },
+  ];
+
+  useEffect(() => {
+    const handleResize = () => setIsSidebarOpen(window.innerWidth >= 768);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => { dispatch(fetchEduvizSessions()); }, [dispatch]);
+
+  useEffect(() => {
+    if (sessionId) {
+      if (!activeSession || activeSession.id !== sessionId) {
+        dispatch(fetchEduvizSessionById(sessionId));
+      }
+    } else {
+      if (activeSession) dispatch(setActiveSession(null));
+    }
+  }, [sessionId, dispatch]);
+
+  const handleNewSession = () => {
+    dispatch(setActiveSession(null));
+    dispatch(clearEduvizState());
+    navigate(currentTenant ? `/${currentTenant}/eduviz` : '/eduviz');
+  };
+
+  const handleSelectSession = (session) => {
+    navigate(currentTenant ? `/${currentTenant}/eduviz/${session.id}` : `/eduviz/${session.id}`);
+  };
+
+  const handlePin = (session) => {
+    dispatch(togglePinEduvizSession({ sessionId: session.id, isPinned: !session.is_pinned }));
+  };
+
+  const handleDelete = (id) => {
+    if (sessionId === id) {
+      dispatch(setActiveSession(null));
+      dispatch(clearEduvizState());
+      navigate(currentTenant ? `/${currentTenant}/eduviz` : '/eduviz');
+    }
+    dispatch(deleteEduvizSession(id));
+  };
+
+  const handleLogout = () => { dispatch(logout()); window.location.reload(); };
+
+  const pinnedSessions = useMemo(() => (sessions || []).filter(s => s.is_pinned), [sessions]);
+  const unpinnedSessions = useMemo(() => (sessions || []).filter(s => !s.is_pinned), [sessions]);
+  const filteredSessions = useMemo(() => {
+    if (searchQuery.trim().length < 2) return null;
+    const q = searchQuery.toLowerCase();
+    return (sessions || []).filter(s => (s.title || '').toLowerCase().includes(q));
+  }, [sessions, searchQuery]);
+
+  useDocumentTitle('EduViz Benchmark');
+
+  return (
+    <div className="flex flex-col h-screen bg-gray-50">
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* Sidebar */}
+        <div className={`bg-white border-r border-gray-200 flex flex-col h-full transition-all duration-300
+          fixed inset-y-0 left-0 z-40 w-64 transform ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+          md:relative md:z-auto md:transform-none ${isSidebarOpen ? 'md:w-64' : 'md:w-14'}`}>
+
+          {/* Sidebar header */}
+          <div className="flex-shrink-0">
+            <div className="flex items-center h-[65px] px-4 border-b border-gray-200">
+              {isSidebarOpen ? (
+                <div className="flex items-center justify-between w-full">
+                  <div className="relative group/arena"
+                    onMouseEnter={() => setIsArenaSwitcherOpen(true)}
+                    onMouseLeave={() => setIsArenaSwitcherOpen(false)}>
+                    <button className="flex items-center gap-2 hover:bg-gray-100 rounded-lg px-2 py-1.5 transition-colors">
+                      <BotMessageSquare className="text-orange-500 flex-shrink-0" size={20} />
+                      <span className="font-bold text-lg whitespace-nowrap truncate">Indic OCR Arena</span>
+                      <ChevronDown size={16} className={`text-gray-500 transition-transform ${isArenaSwitcherOpen ? 'rotate-180' : ''}`} />
+                    </button>
+                    {isArenaSwitcherOpen && (
+                      <div className="absolute top-full left-0 pt-1 w-48 z-50">
+                        <div className="bg-white rounded-lg shadow-xl border border-gray-100 py-1">
+                          {arenaOptions.map((arena) => {
+                            const Icon = arena.icon;
+                            const isActive = arena.key === 'OCR';
+                            return (
+                              <button key={arena.key}
+                                onClick={() => { navigate(currentTenant ? `/${currentTenant}${arena.url}` : arena.url); setIsArenaSwitcherOpen(false); }}
+                                className={`w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 flex items-center gap-3 ${isActive ? 'bg-orange-50 text-orange-700' : 'text-gray-700'}`}>
+                                <Icon size={18} className={isActive ? 'text-orange-500' : 'text-gray-500'} />
+                                <span>Indic {arena.name}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <button onClick={() => setIsSidebarOpen(false)} className="p-1.5 rounded-lg hover:bg-gray-100">
+                    <PanelLeftClose size={18} />
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center justify-center w-full">
+                  <button onClick={() => setIsSidebarOpen(true)} className="relative group p-1.5 rounded-lg hover:bg-gray-100">
+                    <BotMessageSquare size={20} className="text-orange-500 transition-transform group-hover:scale-0" />
+                    <PanelLeftOpen size={18} className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-gray-700 transition-transform scale-0 group-hover:scale-100" />
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div className="p-2">
+              <SidebarItem icon={Plus} text="New Session" isOpen={isSidebarOpen} onClick={handleNewSession} bordered={true} />
+            </div>
+
+            {isSidebarOpen && sessions.length > 0 && (
+              <div className="px-2 pb-2">
+                {isSearchOpen ? (
+                  <div className="flex items-center gap-2 px-2 py-1.5 bg-gray-100 rounded-lg">
+                    <Search size={14} className="text-gray-400 flex-shrink-0" />
+                    <input autoFocus type="text" value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      placeholder="Search sessions..."
+                      className="flex-1 bg-transparent text-sm text-gray-700 outline-none placeholder-gray-400" />
+                    <button onClick={() => { setSearchQuery(''); setIsSearchOpen(false); }} className="text-gray-400 hover:text-gray-600">
+                      <X size={14} />
+                    </button>
+                  </div>
+                ) : (
+                  <button onClick={() => setIsSearchOpen(true)}
+                    className="w-full flex items-center gap-2 px-2 py-1.5 text-sm text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors">
+                    <Search size={14} /><span>Search sessions...</span>
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Session list */}
+          <div className={`flex-1 overflow-y-auto min-h-0 ${isSidebarOpen ? 'p-2' : 'opacity-0 pointer-events-none'}`}>
+            {isSidebarOpen && (
+              <>
+                {filteredSessions ? (
+                  filteredSessions.length > 0 ? filteredSessions.map(s => (
+                    <SessionItem key={s.id} session={s} isActive={sessionId === s.id}
+                      onClick={() => handleSelectSession(s)} onPin={handlePin}
+                      onRename={() => {}} onDelete={handleDelete} />
+                  )) : (
+                    <p className="px-3 py-6 text-xs text-center text-gray-400">No sessions match</p>
+                  )
+                ) : (
+                  <>
+                    {pinnedSessions.length > 0 && (
+                      <div className="mb-4">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase px-2.5 mb-2 flex items-center gap-2">
+                          <Pin size={12} /> Pinned
+                        </h3>
+                        {pinnedSessions.map(s => (
+                          <SessionItem key={s.id} session={s} isActive={sessionId === s.id}
+                            onClick={() => handleSelectSession(s)} onPin={handlePin}
+                            onRename={() => {}} onDelete={handleDelete} />
+                        ))}
+                      </div>
+                    )}
+                    {unpinnedSessions.map(s => (
+                      <SessionItem key={s.id} session={s} isActive={sessionId === s.id}
+                        onClick={() => handleSelectSession(s)} onPin={handlePin}
+                        onRename={() => {}} onDelete={handleDelete} />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="border-t border-gray-200 p-2 flex-shrink-0">
+            {isAnonymous ? (
+              <SidebarItem icon={LogIn} text="Sign in to save" isOpen={isSidebarOpen} onClick={() => setShowAuthModal(true)} />
+            ) : (
+              <SidebarItem icon={LogOut} text="Logout" isOpen={isSidebarOpen} onClick={handleLogout} />
+            )}
+            <div className={`flex items-center p-2 mt-1 rounded-lg ${isSidebarOpen ? 'justify-start gap-3' : 'justify-center'}`}>
+              <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 ${isAnonymous ? 'bg-gray-200' : 'bg-orange-500 text-white'}`}>
+                <User size={18} />
+              </div>
+              <div className={`overflow-hidden transition-all ${isSidebarOpen ? 'max-w-[180px]' : 'max-w-0'}`}>
+                <p className="text-sm font-semibold whitespace-nowrap truncate">
+                  {isAnonymous ? 'Guest User' : (user?.display_name || user?.email)}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <header className="bg-white border-b border-gray-200 px-6 flex-shrink-0">
+            <div className="flex items-center h-[64px]">
+              <div className="flex items-center gap-3 w-full min-w-0">
+                {!isSidebarOpen && (
+                  <button className="p-2 rounded-lg hover:bg-gray-100" onClick={() => setIsSidebarOpen(true)}>
+                    <PanelLeftOpen size={20} />
+                  </button>
+                )}
+                <div className="min-w-0 flex-1">
+                  <EduVizModelSelector />
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <EduVizWindow />
+        </div>
+
+        {isSidebarOpen && (
+          <div className="fixed inset-0 bg-black/30 z-30 md:hidden" onClick={() => setIsSidebarOpen(false)} />
+        )}
+      </div>
+
+      <AuthModal isOpen={showAuthModal} onClose={() => setShowAuthModal(false)} session_type="EDUVIZ" />
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizMetadataBar.jsx
+++ b/src/features/eduviz/components/EduVizMetadataBar.jsx
@@ -59,13 +59,13 @@ function MetaSelect({ label, field, options, value }) {
   const dispatch = useDispatch();
   return (
     <div className="flex items-center gap-2 min-w-0">
-      <label className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide whitespace-nowrap">{label}</label>
+      <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-widest whitespace-nowrap">{label}</label>
       <select
         value={value}
         onChange={(e) => dispatch(setMetadataField({ field, value: e.target.value }))}
-        className="text-xs bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-gray-700 focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 min-w-[90px] cursor-pointer"
+        className="text-xs bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-white focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 min-w-[100px] cursor-pointer shadow-inner appearance-none transition-colors"
       >
-        <option value="">Select</option>
+        <option value="" className="text-slate-400">Select...</option>
         {options.map(opt => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}
@@ -112,40 +112,20 @@ export function EduVizMetadataBar() {
   };
 
   return (
-    <div className="flex items-center justify-between px-4 py-2 bg-gray-50 border-t border-gray-200 overflow-x-auto flex-shrink-0">
-      <div className="flex items-center gap-4">
+    <div className="flex flex-wrap items-center justify-between gap-y-4 px-6 py-3 bg-slate-900 border-t border-slate-900 flex-shrink-0 shadow-[0_-4px_15px_rgba(0,0,0,0.1)] relative z-20">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
         <MetaSelect label="Grade" field="grade" options={GRADE_OPTIONS} value={metadata.grade} />
-        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Subject" field="subject" options={SUBJECT_OPTIONS} value={metadata.subject} />
-        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Task" field="taskType" options={TASK_TYPE_OPTIONS} value={metadata.taskType} />
-        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Language" field="language" options={LANGUAGE_OPTIONS} value={metadata.language} />
-        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Script" field="script" options={SCRIPT_OPTIONS} value={metadata.script} />
-        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Writing" field="writing" options={WRITING_OPTIONS} value={metadata.writing} />
       </div>
-
-      {/* Submit Button */}
-      <button
-        onClick={handleSubmit}
-        disabled={!messageId || submitStatus === 'saving'}
-        className={`ml-6 flex-shrink-0 flex items-center justify-center gap-2 px-6 py-2 rounded-lg text-sm font-bold transition-all duration-200 ${submitStatus === 'saved'
-            ? 'bg-green-500 text-white'
-            : submitStatus === 'error'
-              ? 'bg-red-500 text-white'
-              : 'bg-slate-800 hover:bg-slate-900 text-white disabled:opacity-40 disabled:cursor-not-allowed'
-          }`}
-      >
-        {submitStatus === 'saving' && <Loader2 size={16} className="animate-spin" />}
-        {submitStatus === 'saved' && <CheckCircle2 size={16} />}
-        {submitStatus === 'error' && <AlertCircle size={16} />}
-        {submitStatus === 'saving' ? 'Saving…' :
-          submitStatus === 'saved' ? 'Saved!' :
-            submitStatus === 'error' ? 'Error' :
-              'Submit Annotation'}
-      </button>
     </div>
   );
 }

--- a/src/features/eduviz/components/EduVizMetadataBar.jsx
+++ b/src/features/eduviz/components/EduVizMetadataBar.jsx
@@ -1,0 +1,151 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { setMetadataField, submitAssessment, setSubmitStatus } from '../store/eduvizSlice';
+import { CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
+import { useEffect } from 'react';
+
+const GRADE_OPTIONS = Array.from({ length: 10 }, (_, i) => ({ value: String(i + 1), label: `Grade ${i + 1}` }));
+
+const SUBJECT_OPTIONS = [
+  { value: 'maths', label: 'Mathematics' },
+  { value: 'science', label: 'Science' },
+  { value: 'english', label: 'English' },
+  { value: 'hindi', label: 'Hindi' },
+  { value: 'social_studies', label: 'Social Studies' },
+  { value: 'other', label: 'Other' },
+];
+
+const TASK_TYPE_OPTIONS = [
+  { value: 'handwriting', label: 'Handwriting' },
+  { value: 'diagram', label: 'Diagram' },
+  { value: 'problem_solving', label: 'Problem Solving' },
+  { value: 'essay', label: 'Essay' },
+  { value: 'fill_blanks', label: 'Fill in the Blanks' },
+  { value: 'other', label: 'Other' },
+];
+
+const LANGUAGE_OPTIONS = [
+  { value: 'english', label: 'English' },
+  { value: 'hindi', label: 'Hindi' },
+  { value: 'tamil', label: 'Tamil' },
+  { value: 'telugu', label: 'Telugu' },
+  { value: 'kannada', label: 'Kannada' },
+  { value: 'bengali', label: 'Bengali' },
+  { value: 'marathi', label: 'Marathi' },
+  { value: 'gujarati', label: 'Gujarati' },
+  { value: 'malayalam', label: 'Malayalam' },
+  { value: 'odia', label: 'Odia' },
+  { value: 'other', label: 'Other' },
+];
+
+const SCRIPT_OPTIONS = [
+  { value: 'latin', label: 'Latin' },
+  { value: 'devanagari', label: 'Devanagari' },
+  { value: 'tamil', label: 'Tamil' },
+  { value: 'telugu', label: 'Telugu' },
+  { value: 'kannada', label: 'Kannada' },
+  { value: 'bengali', label: 'Bengali' },
+  { value: 'gujarati', label: 'Gujarati' },
+  { value: 'malayalam', label: 'Malayalam' },
+  { value: 'odia', label: 'Odia' },
+  { value: 'other', label: 'Other' },
+];
+
+const WRITING_OPTIONS = [
+  { value: 'pen', label: 'Pen' },
+  { value: 'pencil', label: 'Pencil' },
+];
+
+function MetaSelect({ label, field, options, value }) {
+  const dispatch = useDispatch();
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <label className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide whitespace-nowrap">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => dispatch(setMetadataField({ field, value: e.target.value }))}
+        className="text-xs bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-gray-700 focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 min-w-[90px] cursor-pointer"
+      >
+        <option value="">Select</option>
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function EduVizMetadataBar() {
+  const dispatch = useDispatch();
+  const {
+    metadata,
+    submitStatus,
+    activeSession,
+    currentPageIndex,
+    annotationMessageIds,
+    editedAnnotations,
+  } = useSelector(s => s.eduviz);
+
+  const sessionId = activeSession?.id;
+  const pageKey = sessionId ? `${sessionId}_${currentPageIndex}` : null;
+  const messageId = pageKey ? annotationMessageIds?.[pageKey]?.modelA : null;
+
+  // Submit all annotated blocks combined
+  const annotatedBlocks = pageKey ? Object.values(editedAnnotations[pageKey]?.modelA || {}) : [];
+
+  // Reset submit status after 3 seconds
+  useEffect(() => {
+    if (submitStatus === 'saved' || submitStatus === 'error') {
+      const timer = setTimeout(() => dispatch(setSubmitStatus('idle')), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [submitStatus, dispatch]);
+
+  const handleSubmit = () => {
+    if (!messageId) return;
+    dispatch(submitAssessment({
+      messageId,
+      assessment: {
+        metadata,
+        annotatedBlocks,
+      },
+    }));
+  };
+
+  return (
+    <div className="flex items-center justify-between px-4 py-2 bg-gray-50 border-t border-gray-200 overflow-x-auto flex-shrink-0">
+      <div className="flex items-center gap-4">
+        <MetaSelect label="Grade" field="grade" options={GRADE_OPTIONS} value={metadata.grade} />
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <MetaSelect label="Subject" field="subject" options={SUBJECT_OPTIONS} value={metadata.subject} />
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <MetaSelect label="Task" field="taskType" options={TASK_TYPE_OPTIONS} value={metadata.taskType} />
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <MetaSelect label="Language" field="language" options={LANGUAGE_OPTIONS} value={metadata.language} />
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <MetaSelect label="Script" field="script" options={SCRIPT_OPTIONS} value={metadata.script} />
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
+        <MetaSelect label="Writing" field="writing" options={WRITING_OPTIONS} value={metadata.writing} />
+      </div>
+
+      {/* Submit Button */}
+      <button
+        onClick={handleSubmit}
+        disabled={!messageId || submitStatus === 'saving'}
+        className={`ml-6 flex-shrink-0 flex items-center justify-center gap-2 px-6 py-2 rounded-lg text-sm font-bold transition-all duration-200 ${submitStatus === 'saved'
+            ? 'bg-green-500 text-white'
+            : submitStatus === 'error'
+              ? 'bg-red-500 text-white'
+              : 'bg-slate-800 hover:bg-slate-900 text-white disabled:opacity-40 disabled:cursor-not-allowed'
+          }`}
+      >
+        {submitStatus === 'saving' && <Loader2 size={16} className="animate-spin" />}
+        {submitStatus === 'saved' && <CheckCircle2 size={16} />}
+        {submitStatus === 'error' && <AlertCircle size={16} />}
+        {submitStatus === 'saving' ? 'Saving…' :
+          submitStatus === 'saved' ? 'Saved!' :
+            submitStatus === 'error' ? 'Error' :
+              'Submit Annotation'}
+      </button>
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizMetadataBar.jsx
+++ b/src/features/eduviz/components/EduVizMetadataBar.jsx
@@ -58,12 +58,12 @@ const WRITING_OPTIONS = [
 function MetaSelect({ label, field, options, value }) {
   const dispatch = useDispatch();
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-widest whitespace-nowrap">{label}</label>
+    <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 min-w-0 flex-1 sm:flex-initial">
+      <label className="text-[9px] sm:text-[10px] font-bold text-slate-400 uppercase tracking-[0.15em] ml-1 sm:ml-0">{label}</label>
       <select
         value={value}
         onChange={(e) => dispatch(setMetadataField({ field, value: e.target.value }))}
-        className="text-xs bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-white focus:outline-none focus:ring-1 focus:ring-orange-400 focus:border-orange-400 min-w-[100px] cursor-pointer shadow-inner appearance-none transition-colors"
+        className="w-full sm:w-auto text-xs bg-slate-800 border border-slate-700/50 rounded-lg px-3 py-2 sm:py-1.5 text-white focus:outline-none focus:ring-1 focus:ring-orange-400/50 focus:border-orange-400 min-w-[110px] cursor-pointer shadow-inner appearance-none hover:border-slate-600 transition-colors"
       >
         <option value="" className="text-slate-400">Select...</option>
         {options.map(opt => (
@@ -110,20 +110,14 @@ export function EduVizMetadataBar() {
       },
     }));
   };
-
   return (
-    <div className="flex flex-wrap items-center justify-between gap-y-4 px-6 py-3 bg-slate-900 border-t border-slate-900 flex-shrink-0 shadow-[0_-4px_15px_rgba(0,0,0,0.1)] relative z-20">
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+    <div className="w-full flex-shrink-0 bg-slate-900 border-t border-slate-800 shadow-[0_-4px_20px_rgba(0,0,0,0.15)] relative z-30">
+      <div className="grid grid-cols-2 lg:flex lg:flex-wrap items-center gap-x-4 sm:gap-x-8 gap-y-4 px-4 sm:px-6 py-4">
         <MetaSelect label="Grade" field="grade" options={GRADE_OPTIONS} value={metadata.grade} />
-        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Subject" field="subject" options={SUBJECT_OPTIONS} value={metadata.subject} />
-        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Task" field="taskType" options={TASK_TYPE_OPTIONS} value={metadata.taskType} />
-        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Language" field="language" options={LANGUAGE_OPTIONS} value={metadata.language} />
-        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Script" field="script" options={SCRIPT_OPTIONS} value={metadata.script} />
-        <div className="w-[1px] h-6 bg-slate-700/50 flex-shrink-0" />
         <MetaSelect label="Writing" field="writing" options={WRITING_OPTIONS} value={metadata.writing} />
       </div>
     </div>

--- a/src/features/eduviz/components/EduVizModelSelector.jsx
+++ b/src/features/eduviz/components/EduVizModelSelector.jsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { setSelectedModels, setActiveSession, clearEduvizState } from '../store/eduvizSlice';
+import { ModelDropdown } from '../../ocr/components/ModelDropdown';
+import { fetchModelsOCR } from '../../models/store/modelsSlice';
+import { useTenant } from '../../../shared/context/TenantContext';
+
+/**
+ * EduViz model selector — direct mode only, single model.
+ * Reads from eduviz slice instead of ocrChat.
+ */
+export function EduVizModelSelector() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { tenant: urlTenant } = useParams();
+  const { tenant: contextTenant } = useTenant();
+  const currentTenant = urlTenant || contextTenant;
+  const { activeSession, selectedModels } = useSelector(s => s.eduviz);
+  const { models, loading } = useSelector(s => s.models);
+
+  useEffect(() => {
+    dispatch(fetchModelsOCR(currentTenant));
+  }, [dispatch, currentTenant]);
+
+  const modelsInUse = {
+    modelA: activeSession?.model_a?.id || selectedModels?.modelA,
+  };
+
+  // Auto-select first model when models load
+  useEffect(() => {
+    if (models.length > 0 && !activeSession) {
+      const isValid = selectedModels?.modelA && models.some(m => m.id === selectedModels.modelA);
+      if (!isValid) {
+        dispatch(setSelectedModels({ modelA: models[0].id }));
+      }
+    }
+  }, [models, activeSession, dispatch]);
+
+  const handleModelSelect = (model) => {
+    const isChangingActive = activeSession && activeSession.model_a?.id !== model.id;
+    dispatch(setSelectedModels({ modelA: model.id }));
+    if (isChangingActive) {
+      dispatch(setActiveSession(null));
+      dispatch(clearEduvizState());
+      navigate(currentTenant ? `/${currentTenant}/eduviz` : '/eduviz');
+    }
+  };
+
+  if (loading || (models.length > 0 && !modelsInUse.modelA)) {
+    return <div className="text-sm text-gray-500 animate-pulse">Initializing...</div>;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="px-3 py-1.5 rounded-xl bg-orange-50 text-orange-600 font-semibold text-xs border border-orange-100">
+        EduViz Benchmark
+      </span>
+      <span className="text-gray-300 font-light text-2xl hidden sm:inline">/</span>
+      <ModelDropdown
+        models={models}
+        selectedModelId={modelsInUse.modelA}
+        onSelect={handleModelSelect}
+      />
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizModelSelector.jsx
+++ b/src/features/eduviz/components/EduVizModelSelector.jsx
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { setSelectedModels, setActiveSession, clearEduvizState } from '../store/eduvizSlice';
 import { ModelDropdown } from '../../ocr/components/ModelDropdown';
+import { ModeDropdown } from '../../ocr/components/ModeDropdown';
 import { fetchModelsOCR } from '../../models/store/modelsSlice';
 import { useTenant } from '../../../shared/context/TenantContext';
 
@@ -47,16 +48,24 @@ export function EduVizModelSelector() {
     }
   };
 
+  const handleModeChange = (newMode) => {
+    if (newMode === 'direct') {
+      if (activeSession) {
+        dispatch(setActiveSession(null));
+        dispatch(clearEduvizState());
+      }
+      navigate(currentTenant ? `/${currentTenant}/ocr` : '/ocr');
+    }
+  };
+
   if (loading || (models.length > 0 && !modelsInUse.modelA)) {
     return <div className="text-sm text-gray-500 animate-pulse">Initializing...</div>;
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="px-3 py-1.5 rounded-xl bg-orange-50 text-orange-600 font-semibold text-xs border border-orange-100">
-        EduViz Benchmark
-      </span>
-      <span className="text-gray-300 font-light text-2xl hidden sm:inline">/</span>
+    <div className="flex items-center gap-1 sm:gap-2">
+      <ModeDropdown currentMode="eduviz" onModeChange={handleModeChange} />
+      <span className="text-gray-300 font-light text-lg sm:text-2xl hidden sm:inline">/</span>
       <ModelDropdown
         models={models}
         selectedModelId={modelsInUse.modelA}

--- a/src/features/eduviz/components/EduVizUploadInput.jsx
+++ b/src/features/eduviz/components/EduVizUploadInput.jsx
@@ -1,0 +1,232 @@
+import { useRef, useCallback, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { Upload, FileText, Image, X, ScanText, ChevronRight } from 'lucide-react';
+import { useEduVizJob } from '../hooks/useEduVizJob';
+
+function Toggle({ checked, onChange, disabled }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+        disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
+      } ${checked ? 'bg-orange-500' : 'bg-gray-200'}`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow ring-0 transition-transform duration-200 ${
+          checked ? 'translate-x-4' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/tiff', 'image/webp', 'image/bmp', 'application/pdf'];
+const MAX_SIZE_MB = 20;
+
+function formatFileSize(bytes) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function EduVizUploadInput() {
+  const fileInputRef = useRef(null);
+  const { submitImage } = useEduVizJob();
+  const { processingStatus, processingError } = useSelector(s => s.eduviz);
+
+  const [generateBoxes, setGenerateBoxes] = useState(true);
+  const [generateText, setGenerateText] = useState(true);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const stageFile = useCallback((file) => {
+    if (!file) return;
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert('Please upload a JPEG, PNG, TIFF, WEBP, BMP, or PDF file.');
+      return;
+    }
+    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+      alert(`File must be smaller than ${MAX_SIZE_MB}MB.`);
+      return;
+    }
+    setSelectedFile(file);
+    if (file.type !== 'application/pdf') {
+      setPreviewUrl(URL.createObjectURL(file));
+    } else {
+      setPreviewUrl(null);
+    }
+  }, []);
+
+  const clearFile = () => {
+    setSelectedFile(null);
+    setPreviewUrl(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleAnalyze = async () => {
+    if (!selectedFile) return;
+    await submitImage(selectedFile, { generateBoxes, generateText });
+  };
+
+  const handleInputChange = (e) => {
+    if (e.target.files?.[0]) stageFile(e.target.files[0]);
+  };
+
+  const handleDrop = useCallback((e) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    if (e.dataTransfer.files?.[0]) stageFile(e.dataTransfer.files[0]);
+  }, [stageFile]);
+
+  const handleDragOver = (e) => { e.preventDefault(); setIsDragOver(true); };
+  const handleDragLeave = () => setIsDragOver(false);
+
+  const isProcessing = processingStatus === 'uploading' || processingStatus === 'processing';
+
+  return (
+    <div className="w-full flex flex-col items-center justify-center gap-6 p-6">
+      {/* Hero */}
+      <div className="flex flex-col items-center text-center mb-2">
+        <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-400 to-amber-500 mb-4 shadow-lg shadow-orange-200">
+          <ScanText size={28} className="text-white" />
+        </div>
+        <h1 className="text-3xl md:text-5xl font-bold text-slate-800 tracking-tight">
+          EduViz{' '}
+          <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-yellow-500 bg-clip-text text-transparent">
+            Benchmark
+          </span>
+        </h1>
+        <p className="mt-4 max-w-3xl text-md md:text-lg text-slate-600">
+          Upload handwritten student samples for OCR analysis and teacher evaluation.
+        </p>
+        <p className="max-w-3xl text-md md:text-lg text-slate-600">
+          Draw error boxes, rate quality, and build India's largest handwriting benchmark dataset.
+        </p>
+      </div>
+
+      {/* Main card */}
+      <div className="w-full max-w-lg">
+        {isProcessing ? (
+          <div className="rounded-2xl border border-orange-200 bg-orange-50 px-6 py-8 flex flex-col items-center gap-3 text-center">
+            <div className="w-10 h-10 border-[3px] border-orange-500 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm font-medium text-orange-600">
+              {processingStatus === 'uploading' ? 'Uploading document…' : 'Running OCR…'}
+            </p>
+            <p className="text-xs text-orange-400">This may take a few seconds</p>
+          </div>
+
+        ) : selectedFile ? (
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+            <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100">
+              {previewUrl ? (
+                <img
+                  src={previewUrl}
+                  alt="Preview"
+                  className="w-12 h-12 rounded-lg object-cover flex-shrink-0 border border-gray-100"
+                />
+              ) : (
+                <div className="w-12 h-12 rounded-lg bg-orange-50 flex items-center justify-center flex-shrink-0 border border-orange-100">
+                  <FileText size={22} className="text-orange-400" />
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-800 truncate">{selectedFile.name}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{formatFileSize(selectedFile.size)}</p>
+              </div>
+              <button
+                onClick={clearFile}
+                className="p-1.5 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors flex-shrink-0"
+                title="Remove file"
+              >
+                <X size={15} />
+              </button>
+            </div>
+
+            <div className="divide-y divide-gray-100">
+              <label className="flex items-center justify-between px-4 py-3 cursor-pointer">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium text-gray-800">Generate boxes</span>
+                  <span className="text-xs text-gray-400">Automatically detect layout regions</span>
+                </div>
+                <Toggle checked={generateBoxes} onChange={setGenerateBoxes} />
+              </label>
+              <label className={`flex items-center justify-between px-4 py-3 transition-opacity ${generateBoxes ? 'cursor-pointer' : 'opacity-40 pointer-events-none'}`}>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium text-gray-800">Generate text within</span>
+                  <span className="text-xs text-gray-400">Transcribe text inside each detected region</span>
+                </div>
+                <Toggle checked={generateBoxes && generateText} onChange={setGenerateText} disabled={!generateBoxes} />
+              </label>
+            </div>
+
+            <div className="px-4 py-3 bg-gray-50 border-t border-gray-100">
+              <button
+                onClick={handleAnalyze}
+                className="w-full flex items-center justify-center gap-2 py-2.5 bg-orange-500 hover:bg-orange-600 text-white text-sm font-semibold rounded-xl transition-colors"
+              >
+                <ScanText size={16} />
+                Analyse Document
+                <ChevronRight size={15} className="opacity-70" />
+              </button>
+            </div>
+          </div>
+
+        ) : (
+          <div
+            className={`border-2 border-dashed rounded-2xl p-8 text-center transition-all duration-200 cursor-pointer ${
+              isDragOver
+                ? 'border-orange-500 bg-orange-50 scale-[1.01]'
+                : 'border-orange-300 bg-orange-50/30 hover:border-orange-500 hover:bg-orange-50'
+            }`}
+            onClick={() => fileInputRef.current?.click()}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+          >
+            <div className="flex flex-col items-center gap-3">
+              <div className="flex gap-3 text-orange-400">
+                <Image size={36} />
+                <FileText size={36} />
+              </div>
+              <p className="text-base font-medium text-gray-700">
+                Drop a student sample here or click to browse
+              </p>
+              <p className="text-sm text-gray-400">
+                PNG, JPEG, TIFF, WEBP, BMP, PDF &nbsp;·&nbsp; max {MAX_SIZE_MB}MB
+              </p>
+              <button
+                onClick={(e) => { e.stopPropagation(); fileInputRef.current?.click(); }}
+                className="mt-2 flex items-center gap-2 px-4 py-2 bg-orange-500 text-white text-sm font-medium rounded-lg hover:bg-orange-600 transition-colors"
+              >
+                <Upload size={15} />
+                Choose File
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {processingError && (
+        <p className="text-sm text-red-500 max-w-md text-center">{processingError}</p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*,application/pdf"
+        onChange={handleInputChange}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/src/features/eduviz/components/EduVizWindow.jsx
+++ b/src/features/eduviz/components/EduVizWindow.jsx
@@ -1,0 +1,80 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { LoaderCircle, AlertCircle, RefreshCw } from 'lucide-react';
+import { EduVizUploadInput } from './EduVizUploadInput';
+import { EduVizDocumentView } from './EduVizDocumentView';
+import { fetchEduvizSessionById } from '../store/eduvizSlice';
+
+/**
+ * EduVizWindow — top-level state router for the EduViz main area.
+ *
+ * States:
+ *   idle / uploading / processing → EduVizUploadInput
+ *   loading → spinner
+ *   error → error card with retry
+ *   done / streaming → EduVizDocumentView
+ */
+export function EduVizWindow() {
+  const dispatch = useDispatch();
+  const { sessionId: urlSessionId } = useParams();
+  const { activeSession, processingStatus, processingError } = useSelector(s => s.eduviz);
+
+  // Loading state
+  if (processingStatus === 'loading' && urlSessionId) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3 text-gray-400">
+          <LoaderCircle size={32} className="animate-spin" />
+          <span className="text-sm">Loading session…</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (processingStatus === 'error' && urlSessionId) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4 text-center max-w-sm">
+          <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center">
+            <AlertCircle size={24} className="text-red-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-700">Failed to load session</p>
+            {processingError && (
+              <p className="mt-1 text-xs text-gray-400">{processingError}</p>
+            )}
+          </div>
+          <button
+            onClick={() => dispatch(fetchEduvizSessionById(urlSessionId))}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-orange-500 hover:bg-orange-600 text-white text-sm font-medium transition-colors"
+          >
+            <RefreshCw size={14} />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Ready to show document view
+  const isReady = (processingStatus === 'done' || processingStatus === 'streaming')
+    && activeSession
+    && (!urlSessionId || activeSession.id === urlSessionId);
+
+  if (!isReady) {
+    return (
+      <div className="flex-1 flex flex-col overflow-y-auto w-full">
+        <div className="min-h-full flex flex-col items-center py-8">
+          <EduVizUploadInput />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <EduVizDocumentView sessionId={activeSession.id} />
+    </div>
+  );
+}

--- a/src/features/eduviz/components/StarRating.jsx
+++ b/src/features/eduviz/components/StarRating.jsx
@@ -18,8 +18,7 @@ export function StarRating({ label, score, maxScore = 5, onChange }) {
                 title={`${i + 1}/${maxScore}`}
               >
                 <Star
-                  size={20}
-                  className={filled ? 'text-amber-400' : 'text-gray-300'}
+                  className={`${filled ? 'text-amber-400' : 'text-gray-300'} w-4 h-4 sm:w-5 sm:h-5`}
                   fill={filled ? '#fbbf24' : 'none'}
                   strokeWidth={1.5}
                 />

--- a/src/features/eduviz/components/StarRating.jsx
+++ b/src/features/eduviz/components/StarRating.jsx
@@ -1,0 +1,36 @@
+import { Star } from 'lucide-react';
+
+export function StarRating({ label, score, maxScore = 5, onChange }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium text-gray-700">{label}</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <div className="flex items-center gap-0.5">
+          {Array.from({ length: maxScore }, (_, i) => {
+            const filled = i < score;
+            return (
+              <button
+                key={i}
+                onClick={() => onChange(i + 1 === score ? 0 : i + 1)}
+                className="p-0.5 transition-transform hover:scale-110"
+                title={`${i + 1}/${maxScore}`}
+              >
+                <Star
+                  size={20}
+                  className={filled ? 'text-amber-400' : 'text-gray-300'}
+                  fill={filled ? '#fbbf24' : 'none'}
+                  strokeWidth={1.5}
+                />
+              </button>
+            );
+          })}
+        </div>
+        <span className="text-xs text-gray-400 tabular-nums ml-1 w-8 text-right">
+          {score}/{maxScore}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/eduviz/hooks/useEduVizJob.js
+++ b/src/features/eduviz/hooks/useEduVizJob.js
@@ -1,0 +1,163 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { apiClient, fetchWithAuth } from '../../../shared/api/client';
+import { endpoints } from '../../../shared/api/endpoints';
+import { useTenant } from '../../../shared/context/TenantContext';
+import {
+  createEduvizSession,
+  setPages,
+  setCurrentPageIndex,
+  setAnnotationMessageId,
+  streamAnnotation,
+  setProcessingStatus,
+  setProcessingError,
+  updateSessionTitle,
+} from '../store/eduvizSlice';
+
+export function useEduVizJob() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { tenant: urlTenant } = useParams();
+  const { tenant: contextTenant } = useTenant();
+  const tenant = urlTenant || contextTenant;
+
+  const { selectedModels } = useSelector(s => s.eduviz);
+
+  const getTenantUrl = useCallback((path) => {
+    if (tenant) return `${apiClient.defaults.baseURL}/${tenant}${path}`;
+    return `${apiClient.defaults.baseURL}${path}`;
+  }, [tenant]);
+
+  /** Stream OCR for a single page */
+  const streamPage = useCallback(async ({
+    sessionId, pageIndex, page, generateText,
+  }) => {
+    const pageKey = `${sessionId}_${pageIndex}`;
+
+    const userMessageId = uuidv4();
+    const aiMessageIdA = uuidv4();
+
+    const userMessage = {
+      id: userMessageId,
+      role: 'user',
+      image_path: page.path,
+      content: '',
+      status: 'pending',
+    };
+    const aiMessageA = {
+      id: aiMessageIdA,
+      role: 'assistant',
+      content: '',
+      parent_message_ids: [userMessageId],
+      status: 'pending',
+      participant: 'a',
+    };
+
+    const messages = [userMessage, aiMessageA];
+
+    dispatch(setAnnotationMessageId({ sessionId: pageKey, participant: 'modelA', messageId: aiMessageIdA }));
+
+    const response = await fetchWithAuth(getTenantUrl(endpoints.messages.stream), {
+      method: 'POST',
+      body: JSON.stringify({
+        session_id: sessionId,
+        messages,
+        mode: 'EDUVIZ',
+        generate_text_within: generateText,
+      }),
+    });
+
+    if (!response.ok) throw new Error(`OCR stream failed for page ${pageIndex + 1}: ${response.status}`);
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        if (line.startsWith('aa:')) {
+          try { dispatch(streamAnnotation({ sessionId: pageKey, participant: 'modelA', annotation: JSON.parse(line.slice(3)) })); }
+          catch (e) { console.error('Failed to parse aa:', e); }
+        } else if (line.startsWith('ad:')) {
+          try { const d = JSON.parse(line.slice(3)); if (d.finishReason === 'error') console.error('Model error:', d.error); }
+          catch (_) {}
+          break;
+        }
+      }
+    }
+  }, [dispatch, getTenantUrl]);
+
+  const submitImage = useCallback(async (file, { generateBoxes = true, generateText = true } = {}) => {
+    try {
+      dispatch(setProcessingStatus('uploading'));
+
+      const formData = new FormData();
+      formData.append('file', file);
+      const uploadUrl = tenant
+        ? `/${tenant}${endpoints.messages.upload_ocr_image}`
+        : endpoints.messages.upload_ocr_image;
+
+      const uploadRes = await apiClient.post(uploadUrl, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      const { pages } = uploadRes.data;
+      dispatch(setPages(pages));
+      dispatch(setCurrentPageIndex(0));
+
+      dispatch(setProcessingStatus('processing'));
+      const sessionResult = await dispatch(createEduvizSession({
+        mode: 'direct',
+        modelA: selectedModels.modelA,
+        type: 'EDUVIZ',
+        metadata: {
+          source_filename: file.name,
+          page_dimensions: pages.map(p => ({ width: p.width || null, height: p.height || null })),
+        },
+      }));
+
+      if (createEduvizSession.rejected.match(sessionResult)) throw new Error('Failed to create session');
+
+      const session = sessionResult.payload;
+      const sessionId = session.id;
+
+      if (!generateBoxes) {
+        dispatch(setProcessingStatus('done'));
+        navigate(tenant ? `/${tenant}/eduviz/${sessionId}` : `/eduviz/${sessionId}`);
+        return;
+      }
+
+      dispatch(setProcessingStatus('streaming'));
+      navigate(tenant ? `/${tenant}/eduviz/${sessionId}` : `/eduviz/${sessionId}`);
+
+      for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+        await streamPage({ sessionId, pageIndex, page: pages[pageIndex], generateText });
+
+        if (pageIndex === 0) {
+          try {
+            const titleRes = await apiClient.post(`/sessions/${sessionId}/generate_title/`);
+            if (titleRes.data?.title) dispatch(updateSessionTitle({ sessionId, title: titleRes.data.title }));
+          } catch (_) { /* non-critical */ }
+        }
+      }
+
+      dispatch(setProcessingStatus('done'));
+
+    } catch (err) {
+      console.error('EduViz job failed:', err);
+      dispatch(setProcessingError(err.message || 'Failed to process document.'));
+    }
+  }, [dispatch, navigate, tenant, selectedModels, streamPage]);
+
+  return { submitImage };
+}

--- a/src/features/eduviz/store/eduvizSlice.js
+++ b/src/features/eduviz/store/eduvizSlice.js
@@ -1,0 +1,554 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { apiClient } from '../../../shared/api/client';
+import { endpoints } from '../../../shared/api/endpoints';
+import { v4 as uuidv4 } from 'uuid';
+
+// ── Undo/Redo helpers ────────────────────────────────────────────────────────
+const MAX_HISTORY = 50;
+
+function ensureHistory(state, sessionId, participant) {
+  if (!state.annotationHistory[sessionId]) state.annotationHistory[sessionId] = { modelA: [] };
+  if (!state.annotationFuture[sessionId])  state.annotationFuture[sessionId]  = { modelA: [] };
+}
+
+function pushHistory(state, sessionId, participant) {
+  ensureHistory(state, sessionId, participant);
+  const current = state.annotations[sessionId]?.[participant] || [];
+  const stack = state.annotationHistory[sessionId][participant] || [];
+  state.annotationHistory[sessionId][participant] = stack;
+  stack.push(current.map(a => ({ ...a, box: [...a.box] })));
+  if (stack.length > MAX_HISTORY) stack.shift();
+  state.annotationFuture[sessionId][participant] = [];
+}
+
+function syncEdited(state, sessionId, participant) {
+  const arr = state.annotations[sessionId]?.[participant] || [];
+  if (!state.editedAnnotations[sessionId]) state.editedAnnotations[sessionId] = { modelA: {} };
+  const byId = {};
+  arr.forEach(a => { byId[a.id] = { ...a }; });
+  state.editedAnnotations[sessionId][participant] = byId;
+}
+
+// ── Async thunks ─────────────────────────────────────────────────────────────
+export const createEduvizSession = createAsyncThunk(
+  'eduviz/createSession',
+  async ({ mode, modelA, type, metadata }) => {
+    const response = await apiClient.post(endpoints.sessions.create, {
+      mode,
+      model_a_id: modelA,
+      session_type: type,
+      ...(metadata && { metadata }),
+    });
+    return response.data;
+  }
+);
+
+export const fetchEduvizSessions = createAsyncThunk(
+  'eduviz/fetchSessions',
+  async () => {
+    const response = await apiClient.get(endpoints.sessions.list_eduviz);
+    return response.data;
+  }
+);
+
+export const fetchEduvizSessionById = createAsyncThunk(
+  'eduviz/fetchSessionById',
+  async (sessionId) => {
+    const response = await apiClient.get(`/sessions/${sessionId}/`);
+    return response.data;
+  }
+);
+
+export const renameEduvizSession = createAsyncThunk(
+  'eduviz/renameSession',
+  async ({ sessionId, title }, { rejectWithValue }) => {
+    try {
+      const response = await apiClient.patch(`/sessions/${sessionId}/`, { title });
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response.data);
+    }
+  }
+);
+
+export const deleteEduvizSession = createAsyncThunk(
+  'eduviz/deleteSession',
+  async (sessionId, { rejectWithValue }) => {
+    try {
+      await apiClient.delete(`/sessions/${sessionId}/`);
+      return sessionId;
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+export const togglePinEduvizSession = createAsyncThunk(
+  'eduviz/togglePinSession',
+  async ({ sessionId, isPinned }, { rejectWithValue }) => {
+    try {
+      const response = await apiClient.patch(`/sessions/${sessionId}/`, { is_pinned: isPinned });
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response.data);
+    }
+  }
+);
+
+export const submitAssessment = createAsyncThunk(
+  'eduviz/submitAssessment',
+  async ({ messageId, assessment }, { rejectWithValue }) => {
+    try {
+      const response = await apiClient.post(endpoints.messages.submitAssessment(messageId), { assessment });
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data);
+    }
+  }
+);
+
+// ── Slice ────────────────────────────────────────────────────────────────────
+const eduvizSlice = createSlice({
+  name: 'eduviz',
+  initialState: {
+    sessions: [],
+    activeSession: null,
+    messages: {},
+    loading: false,
+    error: null,
+    selectedModels: { modelA: null },
+
+    // Document state
+    pages: [],
+    currentPageIndex: 0,
+    annotations: {},
+    annotationMessageIds: {},
+    annotationHistory: {},
+    annotationFuture: {},
+    activeAnnotationId: null,
+    selectedAnnotationId: null,
+    zoomLevel: 1.0,
+    editedAnnotations: {},
+    processingStatus: 'idle',
+    processingError: null,
+    canvasMode: 'select',
+    drawType: 'spelling_error',
+
+    // Metadata state
+    metadata: {
+      grade: '',
+      subject: '',
+      taskType: '',
+      language: '',
+      script: '',
+      writing: '',
+    },
+
+    submitStatus: 'idle', // 'idle' | 'saving' | 'saved' | 'error'
+  },
+  reducers: {
+    setActiveSession: (state, action) => {
+      state.activeSession = action.payload;
+    },
+    setPages: (state, action) => {
+      state.pages = action.payload;
+      state.currentPageIndex = 0;
+    },
+    setCurrentPageIndex: (state, action) => {
+      state.currentPageIndex = action.payload;
+      state.selectedAnnotationId = null;
+      state.activeAnnotationId = null;
+    },
+    setAnnotations: (state, action) => {
+      const { sessionId, participant, annotations, messageId } = action.payload;
+      if (!state.annotations[sessionId]) {
+        state.annotations[sessionId] = { modelA: [] };
+      }
+      state.annotations[sessionId][participant] = annotations;
+      if (messageId) {
+        if (!state.annotationMessageIds[sessionId]) state.annotationMessageIds[sessionId] = {};
+        state.annotationMessageIds[sessionId][participant] = messageId;
+      }
+      if (!state.editedAnnotations[sessionId]) {
+        state.editedAnnotations[sessionId] = { modelA: {} };
+      }
+      const byId = {};
+      annotations.forEach(ann => { byId[ann.id] = { ...ann }; });
+      state.editedAnnotations[sessionId][participant] = byId;
+    },
+    setActiveAnnotationId: (state, action) => {
+      state.activeAnnotationId = action.payload;
+    },
+    setSelectedAnnotationId: (state, action) => {
+      state.selectedAnnotationId = action.payload;
+    },
+    setZoomLevel: (state, action) => {
+      state.zoomLevel = Math.min(3.0, Math.max(0.25, action.payload));
+    },
+    setProcessingStatus: (state, action) => {
+      state.processingStatus = action.payload;
+      if (action.payload !== 'error') state.processingError = null;
+    },
+    setProcessingError: (state, action) => {
+      state.processingStatus = 'error';
+      state.processingError = action.payload;
+    },
+    setCanvasMode: (state, action) => {
+      state.canvasMode = action.payload;
+    },
+    setDrawType: (state, action) => {
+      state.drawType = action.payload;
+    },
+    setSelectedModels: (state, action) => {
+      state.selectedModels = action.payload;
+    },
+
+    setSubmitStatus: (state, action) => {
+      state.submitStatus = action.payload;
+    },
+
+    // Metadata
+    setMetadataField: (state, action) => {
+      const { field, value } = action.payload;
+      state.metadata[field] = value;
+    },
+
+    // Annotation editing
+    snapshotAnnotations: (state, action) => {
+      const { sessionId, participant } = action.payload;
+      pushHistory(state, sessionId, participant);
+    },
+    updateAnnotationText: (state, action) => {
+      const { sessionId, participant, annotationId, text } = action.payload;
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        state.editedAnnotations[sessionId][participant][annotationId].text = text;
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) item.text = text;
+      }
+    },
+    updateAnnotationType: (state, action) => {
+      const { sessionId, participant, annotationId, type } = action.payload;
+      pushHistory(state, sessionId, participant);
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        state.editedAnnotations[sessionId][participant][annotationId].type = type;
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) item.type = type;
+      }
+    },
+    updateAnnotationBox: (state, action) => {
+      const { sessionId, participant, annotationId, box } = action.payload;
+      pushHistory(state, sessionId, participant);
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        state.editedAnnotations[sessionId][participant][annotationId].box = box;
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) item.box = box;
+      }
+    },
+    updateAnnotationAssessment: (state, action) => {
+      const { sessionId, participant, annotationId, assessmentUpdate } = action.payload;
+      
+      const applyAssessment = (target) => {
+        if (!target.assessment) {
+          target.assessment = { whyIncorrect: '', suggestedImprovement: '', rubrics: { legibility: 0, spellingAccuracy: 0, contentCorrectness: 0 } };
+        }
+        if (assessmentUpdate.whyIncorrect !== undefined) target.assessment.whyIncorrect = assessmentUpdate.whyIncorrect;
+        if (assessmentUpdate.suggestedImprovement !== undefined) target.assessment.suggestedImprovement = assessmentUpdate.suggestedImprovement;
+        if (assessmentUpdate.rubrics) {
+          target.assessment.rubrics = { ...target.assessment.rubrics, ...assessmentUpdate.rubrics };
+        }
+      };
+
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        applyAssessment(state.editedAnnotations[sessionId][participant][annotationId]);
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) applyAssessment(item);
+      }
+    },
+    deleteAnnotation: (state, action) => {
+      const { sessionId, participant, annotationId } = action.payload;
+      pushHistory(state, sessionId, participant);
+      if (state.annotations[sessionId]?.[participant]) {
+        state.annotations[sessionId][participant] = state.annotations[sessionId][participant].filter(
+          a => a.id !== annotationId
+        );
+      }
+      if (state.editedAnnotations[sessionId]?.[participant]) {
+        delete state.editedAnnotations[sessionId][participant][annotationId];
+      }
+      if (state.selectedAnnotationId === annotationId) state.selectedAnnotationId = null;
+      if (state.activeAnnotationId === annotationId) state.activeAnnotationId = null;
+    },
+    addAnnotation: (state, action) => {
+      const { sessionId, participant, annotation } = action.payload;
+      pushHistory(state, sessionId, participant);
+      if (!state.annotations[sessionId]) state.annotations[sessionId] = { modelA: [] };
+      if (!state.annotations[sessionId][participant]) state.annotations[sessionId][participant] = [];
+      state.annotations[sessionId][participant].push(annotation);
+      if (!state.editedAnnotations[sessionId]) state.editedAnnotations[sessionId] = { modelA: {} };
+      if (!state.editedAnnotations[sessionId][participant]) state.editedAnnotations[sessionId][participant] = {};
+      state.editedAnnotations[sessionId][participant][annotation.id] = { ...annotation };
+    },
+    streamAnnotation: (state, action) => {
+      const { sessionId, participant, annotation } = action.payload;
+      if (!state.annotations[sessionId]) state.annotations[sessionId] = { modelA: [] };
+      if (!state.annotations[sessionId][participant]) state.annotations[sessionId][participant] = [];
+      state.annotations[sessionId][participant].push(annotation);
+      if (!state.editedAnnotations[sessionId]) state.editedAnnotations[sessionId] = { modelA: {} };
+      if (!state.editedAnnotations[sessionId][participant]) state.editedAnnotations[sessionId][participant] = {};
+      state.editedAnnotations[sessionId][participant][annotation.id] = { ...annotation };
+    },
+    setAnnotationMessageId: (state, action) => {
+      const { sessionId, participant, messageId } = action.payload;
+      if (!state.annotationMessageIds[sessionId]) state.annotationMessageIds[sessionId] = {};
+      state.annotationMessageIds[sessionId][participant] = messageId;
+    },
+    undoAnnotation: (state, action) => {
+      const { sessionId, participant } = action.payload;
+      ensureHistory(state, sessionId, participant);
+      const history = state.annotationHistory[sessionId][participant];
+      if (!history || !history.length) return;
+      const current = state.annotations[sessionId]?.[participant] || [];
+      if (!state.annotationFuture[sessionId][participant]) state.annotationFuture[sessionId][participant] = [];
+      state.annotationFuture[sessionId][participant].push(current.map(a => ({ ...a, box: [...a.box] })));
+      state.annotations[sessionId][participant] = history.pop();
+      syncEdited(state, sessionId, participant);
+      state.selectedAnnotationId = null;
+    },
+    redoAnnotation: (state, action) => {
+      const { sessionId, participant } = action.payload;
+      ensureHistory(state, sessionId, participant);
+      const future = state.annotationFuture[sessionId][participant];
+      if (!future || !future.length) return;
+      const current = state.annotations[sessionId]?.[participant] || [];
+      if (!state.annotationHistory[sessionId][participant]) state.annotationHistory[sessionId][participant] = [];
+      state.annotationHistory[sessionId][participant].push(current.map(a => ({ ...a, box: [...a.box] })));
+      state.annotations[sessionId][participant] = future.pop();
+      syncEdited(state, sessionId, participant);
+      state.selectedAnnotationId = null;
+    },
+    updateSessionTitle: (state, action) => {
+      const { sessionId, title } = action.payload;
+      const idx = state.sessions.findIndex(s => s.id === sessionId);
+      if (idx !== -1) state.sessions[idx].title = title;
+      if (state.activeSession?.id === sessionId) state.activeSession.title = title;
+    },
+    clearEduvizState: (state) => {
+      state.pages = [];
+      state.currentPageIndex = 0;
+      state.activeAnnotationId = null;
+      state.selectedAnnotationId = null;
+      state.zoomLevel = 1.0;
+      state.processingStatus = 'idle';
+      state.processingError = null;
+      state.canvasMode = 'select';
+      state.drawType = 'spelling_error';
+      state.metadata = {
+        grade: '',
+        subject: '',
+        taskType: '',
+        language: '',
+        script: '',
+        writing: '',
+      };
+      state.submitStatus = 'idle';
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(createEduvizSession.fulfilled, (state, action) => {
+        const session = action.payload;
+        state.activeSession = session;
+        state.messages[session.id] = [];
+        if (!state.annotations[session.id]) state.annotations[session.id] = { modelA: [] };
+        state.sessions.unshift({
+          id: session.id,
+          mode: session.mode,
+          title: session.title,
+          model_a_name: session.model_a?.display_name || 'Model A',
+          created_at: session.created_at,
+          updated_at: session.updated_at,
+          message_count: 0,
+        });
+      })
+      .addCase(fetchEduvizSessions.fulfilled, (state, action) => {
+        state.sessions = action.payload;
+      })
+      .addCase(fetchEduvizSessionById.pending, (state) => {
+        state.processingStatus = 'loading';
+        state.processingError = null;
+      })
+      .addCase(fetchEduvizSessionById.rejected, (state, action) => {
+        state.processingStatus = 'error';
+        state.processingError = action.error?.message || 'Failed to load session.';
+      })
+      .addCase(fetchEduvizSessionById.fulfilled, (state, action) => {
+        const { session, messages } = action.payload;
+        state.activeSession = session;
+        const exists = state.sessions.find(s => s.id === session.id);
+        if (!exists) state.sessions.unshift(session);
+        if (!state.messages[session.id]) state.messages[session.id] = messages;
+
+        if (messages) {
+          const userMessages = [...messages.filter(m => m.role === 'user')]
+            .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+          if (userMessages.length > 0) {
+            const pageDims = session.metadata?.page_dimensions || [];
+            state.pages = userMessages.map((m, i) => ({
+              path: m.image_path,
+              url: m.temp_image_url || null,
+              width: pageDims[i]?.width || null,
+              height: pageDims[i]?.height || null,
+            }));
+            state.currentPageIndex = 0;
+          }
+
+          const userMsgToPage = {};
+          userMessages.forEach((m, idx) => { userMsgToPage[m.id] = idx; });
+
+          messages.forEach(msg => {
+            if (msg.role !== 'assistant' || !msg.content) return;
+            let ocr_result = null;
+            try { ocr_result = JSON.parse(msg.content); } catch (_) {}
+            if (!Array.isArray(ocr_result) || ocr_result.length === 0) return;
+
+            const parentId = msg.parent_message_ids?.[0];
+            const pageIndex = parentId !== undefined ? (userMsgToPage[parentId] ?? 0) : 0;
+            const pageKey = `${session.id}_${pageIndex}`;
+            const participant = 'modelA';
+
+            if (!state.annotations[pageKey]) state.annotations[pageKey] = { modelA: [] };
+            state.annotations[pageKey][participant] = ocr_result;
+
+            if (!state.annotationMessageIds[pageKey]) state.annotationMessageIds[pageKey] = {};
+            state.annotationMessageIds[pageKey][participant] = msg.id;
+
+            if (!state.editedAnnotations[pageKey]) state.editedAnnotations[pageKey] = { modelA: {} };
+            if (!state.editedAnnotations[pageKey][participant]) state.editedAnnotations[pageKey][participant] = {};
+            ocr_result.forEach(ann => {
+              state.editedAnnotations[pageKey][participant][ann.id] = { ...ann };
+            });
+          });
+
+          state.metadata = {
+            grade: '',
+            subject: '',
+            taskType: '',
+            language: '',
+            script: '',
+            writing: '',
+          };
+
+          // Restore assessment from metadata if available
+          const lastAssistant = messages.filter(m => m.role === 'assistant').pop();
+          if (lastAssistant?.metadata?.eduviz_assessment) {
+            const saved = lastAssistant.metadata.eduviz_assessment;
+            
+            if (saved.metadata) {
+              state.metadata = {
+                grade: saved.metadata.grade || '',
+                subject: saved.metadata.subject || '',
+                taskType: saved.metadata.taskType || '',
+                language: saved.metadata.language || '',
+                script: saved.metadata.script || '',
+                writing: saved.metadata.writing || '',
+              };
+            }
+            
+            // If they saved full blocks (the new way via annotatedBlocks) or legacy errorBoxes
+            const savedBlocks = (saved.annotatedBlocks && Array.isArray(saved.annotatedBlocks)) ? saved.annotatedBlocks : [];
+            const legacyErrorBoxes = (saved.errorBoxes && Array.isArray(saved.errorBoxes)) ? saved.errorBoxes : [];
+            const blocksToRestore = savedBlocks.length > 0 ? savedBlocks : legacyErrorBoxes;
+
+            if (blocksToRestore.length > 0) {
+              const parentId = lastAssistant.parent_message_ids?.[0];
+              const pageIndex = parentId !== undefined ? (userMsgToPage[parentId] ?? 0) : 0;
+              const pageKey = `${session.id}_${pageIndex}`;
+              const participant = 'modelA';
+              
+              if (!state.annotations[pageKey]) state.annotations[pageKey] = { modelA: [] };
+              if (!state.annotations[pageKey][participant]) state.annotations[pageKey][participant] = [];
+              if (!state.editedAnnotations[pageKey]) state.editedAnnotations[pageKey] = { modelA: {} };
+              if (!state.editedAnnotations[pageKey][participant]) state.editedAnnotations[pageKey][participant] = {};
+              
+              // Full replacement of matching blocks to ensure assessment fields populate
+              blocksToRestore.forEach(savedBlock => {
+                const existingIdx = state.annotations[pageKey][participant].findIndex(a => a.id === savedBlock.id);
+                if (existingIdx >= 0) {
+                  state.annotations[pageKey][participant][existingIdx] = { ...state.annotations[pageKey][participant][existingIdx], ...savedBlock };
+                } else {
+                  state.annotations[pageKey][participant].push(savedBlock);
+                }
+                state.editedAnnotations[pageKey][participant][savedBlock.id] = { 
+                  ...state.editedAnnotations[pageKey][participant][savedBlock.id], 
+                  ...savedBlock 
+                };
+              });
+            }
+          }
+        }
+
+        const hasOcrData = messages?.some(m => {
+          if (m.role !== 'assistant' || !m.content) return false;
+          try { const p = JSON.parse(m.content); return Array.isArray(p) && p.length > 0; } catch (_) { return false; }
+        });
+        state.processingStatus = hasOcrData ? 'done' : 'idle';
+      })
+      .addCase(togglePinEduvizSession.pending, (state, action) => {
+        const { sessionId, isPinned } = action.meta.arg;
+        const s = state.sessions.find(s => s.id === sessionId);
+        if (s) s.is_pinned = isPinned;
+      })
+      .addCase(togglePinEduvizSession.fulfilled, (state, action) => {
+        const idx = state.sessions.findIndex(s => s.id === action.payload.id);
+        if (idx !== -1) state.sessions[idx] = { ...state.sessions[idx], ...action.payload };
+      })
+      .addCase(renameEduvizSession.fulfilled, (state, action) => {
+        const { id, title } = action.payload;
+        const idx = state.sessions.findIndex(s => s.id === id);
+        if (idx !== -1) state.sessions[idx].title = title;
+        if (state.activeSession?.id === id) state.activeSession.title = title;
+      })
+      .addCase(deleteEduvizSession.fulfilled, (state, action) => {
+        const sessionId = action.payload;
+        state.sessions = state.sessions.filter(s => s.id !== sessionId);
+        if (state.activeSession?.id === sessionId) state.activeSession = null;
+      })
+      .addCase(submitAssessment.pending, (state) => {
+        state.submitStatus = 'saving';
+      })
+      .addCase(submitAssessment.fulfilled, (state) => {
+        state.submitStatus = 'saved';
+      })
+      .addCase(submitAssessment.rejected, (state) => {
+        state.submitStatus = 'error';
+      });
+  },
+});
+
+export const {
+  setActiveSession, setPages, setCurrentPageIndex, setAnnotations,
+  setActiveAnnotationId, setSelectedAnnotationId,
+  setZoomLevel, setProcessingStatus, setProcessingError,
+  setCanvasMode, setDrawType, setSelectedModels,
+  setSubmitStatus,
+  setMetadataField,
+  snapshotAnnotations,
+  updateAnnotationText, updateAnnotationType, updateAnnotationBox, updateAnnotationAssessment,
+  deleteAnnotation, addAnnotation, streamAnnotation, setAnnotationMessageId,
+  undoAnnotation, redoAnnotation,
+  updateSessionTitle, clearEduvizState,
+} = eduvizSlice.actions;
+
+export default eduvizSlice.reducer;

--- a/src/features/eduviz/store/eduvizSlice.js
+++ b/src/features/eduviz/store/eduvizSlice.js
@@ -234,11 +234,42 @@ const eduvizSlice = createSlice({
       pushHistory(state, sessionId, participant);
       if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
         state.editedAnnotations[sessionId][participant][annotationId].type = type;
+        if (!state.editedAnnotations[sessionId][participant][annotationId].labels) {
+          state.editedAnnotations[sessionId][participant][annotationId].labels = [type];
+        }
       }
       const arr = state.annotations[sessionId]?.[participant];
       if (arr) {
         const item = arr.find(a => a.id === annotationId);
-        if (item) item.type = type;
+        if (item) {
+          item.type = type;
+          if (!item.labels) item.labels = [type];
+        }
+      }
+    },
+    toggleAnnotationLabel: (state, action) => {
+      const { sessionId, participant, annotationId, label } = action.payload;
+      pushHistory(state, sessionId, participant);
+      
+      const applyToggle = (ann) => {
+        if (!ann.labels) {
+          ann.labels = ann.type ? [ann.type] : [];
+        }
+        if (ann.labels.includes(label)) {
+          ann.labels = ann.labels.filter(l => l !== label);
+        } else {
+          ann.labels.push(label);
+        }
+        ann.type = ann.labels.length > 0 ? ann.labels[0] : '';
+      };
+
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        applyToggle(state.editedAnnotations[sessionId][participant][annotationId]);
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) applyToggle(item);
       }
     },
     updateAnnotationBox: (state, action) => {
@@ -545,7 +576,7 @@ export const {
   setSubmitStatus,
   setMetadataField,
   snapshotAnnotations,
-  updateAnnotationText, updateAnnotationType, updateAnnotationBox, updateAnnotationAssessment,
+  updateAnnotationText, updateAnnotationType, toggleAnnotationLabel, updateAnnotationBox, updateAnnotationAssessment,
   deleteAnnotation, addAnnotation, streamAnnotation, setAnnotationMessageId,
   undoAnnotation, redoAnnotation,
   updateSessionTitle, clearEduvizState,

--- a/src/features/eduviz/utils/eduvizTypeColors.js
+++ b/src/features/eduviz/utils/eduvizTypeColors.js
@@ -1,0 +1,42 @@
+// Color map for EduViz error annotation types
+// Values are CSS hex colors used for: box stroke, card border, type badge
+
+export const EDUVIZ_TYPE_COLORS = {
+  spelling_error:       '#ef4444', // red
+  grammar_error:        '#3b82f6', // blue
+  arithmetic_error:     '#22c55e', // green
+  diagram_label_error:  '#f59e0b', // amber
+  conceptual_error:     '#8b5cf6', // purple
+};
+
+export const EDUVIZ_TYPE_LABELS = {
+  spelling_error:       'Spelling',
+  grammar_error:        'Grammar',
+  arithmetic_error:     'Arithmetic',
+  diagram_label_error:  'Diagram',
+  conceptual_error:     'Concept',
+};
+
+export const EDUVIZ_TYPE_OPTIONS = [
+  { value: 'spelling_error',      label: 'Spelling Error',       icon: '✏️' },
+  { value: 'grammar_error',       label: 'Grammar Error',        icon: '📝' },
+  { value: 'arithmetic_error',    label: 'Arithmetic Error',     icon: '🔢' },
+  { value: 'diagram_label_error', label: 'Diagram Label Error',  icon: '🏷️' },
+  { value: 'conceptual_error',    label: 'Conceptual Error',     icon: '💡' },
+];
+
+export function getEduvizTypeColor(type) {
+  return EDUVIZ_TYPE_COLORS[type] || '#6b7280';
+}
+
+export function getEduvizTypeLabel(type) {
+  return EDUVIZ_TYPE_LABELS[type] || type;
+}
+
+// Returns a hex color with an alpha suffix as rgba for fill
+export function hexToRgba(hex, alpha) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}

--- a/src/features/ocr/components/ModeDropdown.jsx
+++ b/src/features/ocr/components/ModeDropdown.jsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
-import { Zap, Check, ChevronDown } from 'lucide-react';
+import { Zap, Check, ChevronDown, GraduationCap } from 'lucide-react';
 
 // OCR Arena currently supports direct mode only.
 const MODES = {
   direct: { icon: Zap, label: 'Direct Mode', description: 'Analyse a document with one model.' },
+  eduviz: { icon: GraduationCap, label: 'EduViz Benchmark', description: 'Teacher evaluation of student handwriting samples.' },
 };
 
 function useOutsideAlerter(ref, callback) {

--- a/src/features/ocr/components/ModelSelector.jsx
+++ b/src/features/ocr/components/ModelSelector.jsx
@@ -38,6 +38,10 @@ export function ModelSelector({ variant = 'full' }) {
   }, [models, activeSession, dispatch]);
 
   const handleModeChange = (newMode) => {
+    if (newMode === 'eduviz') {
+      navigate(currentTenant ? `/${currentTenant}/eduviz` : '/eduviz');
+      return;
+    }
     dispatch(setSelectedMode(newMode));
     if (activeSession) {
       dispatch(setActiveSession(null));

--- a/src/features/ocr/components/OcrCanvas.jsx
+++ b/src/features/ocr/components/OcrCanvas.jsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useBoxEditor } from '../hooks/useBoxEditor';
 import { getTypeColor, hexToRgba, TYPE_OPTIONS } from '../utils/typeColors';
+import { getEduvizTypeColor } from '../../eduviz/utils/eduvizTypeColors';
 import { boxToRect, getHandlePositions, HANDLE_IDS } from '../utils/boxUtils';
 import { setZoomLevel } from '../store/chatSlice';
 import { Copy, Trash2, ChevronRight, Tag } from 'lucide-react';
@@ -20,23 +21,28 @@ function drawResizeHandles(ctx, box, color) {
   }
 }
 
-function drawTypeBadge(ctx, box, typeLabel, color) {
+function drawTypeBadge(ctx, box, typeLabel, color, offsetX = 0) {
   const [x1, y1] = box;
-  const text = typeLabel.slice(0, 8);
-  ctx.font = 'bold 10px system-ui, sans-serif';
+  const text = typeLabel.replace('_error', '').slice(0, 10);
+  ctx.font = 'bold 9px system-ui, sans-serif';
   const tw = ctx.measureText(text).width;
   const bw = tw + 8;
   const bh = 14;
-  const bx = x1;
+  const bx = x1 + offsetX;
   const by = Math.max(0, y1 - bh - 1);
 
   ctx.fillStyle = color;
   ctx.beginPath();
-  ctx.roundRect(bx, by, bw, bh, 2);
+  if (ctx.roundRect) {
+    ctx.roundRect(bx, by, bw, bh, 2);
+  } else {
+    ctx.rect(bx, by, bw, bh);
+  }
   ctx.fill();
 
   ctx.fillStyle = '#ffffff';
-  ctx.fillText(text, bx + 4, by + bh - 3);
+  ctx.fillText(text, bx + 4, by + bh - 4);
+  return bw + 2; // return width + gap
 }
 
 /**
@@ -107,7 +113,10 @@ export function OcrCanvas({
     allAnnotations.forEach((ann) => {
       const isActive   = ann.id === activeAnnotationId;
       const isSelected = ann.id === selectedAnnotationId;
-      const color = getTypeColor(ann.type);
+      const primaryType = ann.labels?.[0] || ann.type || 'other';
+      const color = getEduvizTypeColor(primaryType) !== '#6b7280' 
+        ? getEduvizTypeColor(primaryType) 
+        : getTypeColor(primaryType);
       const { x, y, w, h } = boxToRect(ann.box);
 
       ctx.fillStyle = hexToRgba(color, isActive || isSelected ? 0.15 : 0.08);
@@ -127,8 +136,15 @@ export function OcrCanvas({
       ctx.strokeRect(x, y, w, h);
       ctx.setLineDash([]);
 
-      const typeLabel = ann.type || 'other';
-      drawTypeBadge(ctx, ann.box, typeLabel, color);
+      const labels = ann.labels || (ann.type ? [ann.type] : ['other']);
+      let badgeOffsetX = 0;
+      labels.forEach(label => {
+        // Try both OCR and EduViz color maps
+        const labelColor = getEduvizTypeColor(label) !== '#6b7280' 
+          ? getEduvizTypeColor(label) 
+          : getTypeColor(label);
+        badgeOffsetX += drawTypeBadge(ctx, ann.box, label, labelColor, badgeOffsetX);
+      });
 
       if (isSelected && !compareMode) {
         drawResizeHandles(ctx, ann.box, color);

--- a/src/features/ocr/hooks/useBoxEditor.js
+++ b/src/features/ocr/hooks/useBoxEditor.js
@@ -183,6 +183,7 @@ export function useBoxEditor({
           box,
           text: '',
           type: drawType || 'paragraph',
+          labels: [drawType || 'paragraph'],
           confidence: 1.0,
           page: 1,
         };

--- a/src/features/ocr/store/chatSlice.js
+++ b/src/features/ocr/store/chatSlice.js
@@ -209,11 +209,45 @@ const chatSlice = createSlice({
       pushHistory(state, sessionId, participant);
       if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
         state.editedAnnotations[sessionId][participant][annotationId].type = type;
+        // Also update labels array if it exists as we transition
+        if (!state.editedAnnotations[sessionId][participant][annotationId].labels) {
+          state.editedAnnotations[sessionId][participant][annotationId].labels = [type];
+        }
       }
       const arr = state.annotations[sessionId]?.[participant];
       if (arr) {
         const item = arr.find(a => a.id === annotationId);
-        if (item) item.type = type;
+        if (item) {
+          item.type = type;
+          if (!item.labels) item.labels = [type];
+        }
+      }
+    },
+    toggleAnnotationLabel: (state, action) => {
+      const { sessionId, participant, annotationId, label } = action.payload;
+      pushHistory(state, sessionId, participant);
+      
+      const applyToggle = (ann) => {
+        if (!ann.labels) {
+          // Fallback if labels don't exist yet, use existing type or empty
+          ann.labels = ann.type ? [ann.type] : [];
+        }
+        if (ann.labels.includes(label)) {
+          ann.labels = ann.labels.filter(l => l !== label);
+        } else {
+          ann.labels.push(label);
+        }
+        // Update type for legacy compatibility (set to first label or empty)
+        ann.type = ann.labels.length > 0 ? ann.labels[0] : '';
+      };
+
+      if (state.editedAnnotations[sessionId]?.[participant]?.[annotationId]) {
+        applyToggle(state.editedAnnotations[sessionId][participant][annotationId]);
+      }
+      const arr = state.annotations[sessionId]?.[participant];
+      if (arr) {
+        const item = arr.find(a => a.id === annotationId);
+        if (item) applyToggle(item);
       }
     },
     updateAnnotationBox: (state, action) => {
@@ -472,7 +506,7 @@ export const {
   setCanvasMode, setDrawType, setActiveCompareTab,
   setSelectedMode, setSelectedModels,
   snapshotAnnotations,
-  updateAnnotationText, updateAnnotationType, updateAnnotationBox,
+  updateAnnotationText, updateAnnotationType, toggleAnnotationLabel, updateAnnotationBox,
   deleteAnnotation, duplicateAnnotation, addAnnotation,
   streamAnnotation, setAnnotationMessageId, reorderAnnotations,
   undoAnnotation, redoAnnotation,

--- a/src/shared/api/endpoints.js
+++ b/src/shared/api/endpoints.js
@@ -39,6 +39,7 @@ export const endpoints = {
       list_asr: '/sessions/type/?session_type=ASR',
       list_tts: '/sessions/type/?session_type=TTS',
       list_ocr: '/sessions/type/?session_type=OCR',
+      list_eduviz: '/sessions/type/?session_type=EDUVIZ',
       detail: (id) => `/sessions/${id}/`,
       share: (id) => `/sessions/${id}/share/`,
       export: (id) => `/sessions/${id}/export/`,
@@ -55,6 +56,7 @@ export const endpoints = {
       branch: (id) => `/messages/${id}/branch/`,
       regenerate: (id) => `/messages/${id}/regenerate/`,
       saveAnnotations: (id) => `/messages/${id}/save_annotations/`,
+      submitAssessment: (id) => `/messages/${id}/submit_assessment/`,
       extractRegionText: (id) => `/messages/${id}/extract_region_text/`,
     },
     


### PR DESCRIPTION
## Description

This Pull Request introduces the UI foundation for the **EduViz Assessment Mode**, a dedicated interface living alongside the OCR Arena that empowers evaluators to systematically grade handwritten coursework. 

This update resolves a major architectural pivot requested by the pedagogical team: transitioning away from a global "full-document" evaluation to a granular, **"per-block" assessment model**. Every distinct paragraph, diagram, or drawn spelling error now dynamically tracks its own independent rubric scoring profile.

###  Key Features
- **Per-Block Assessment Panel:** Evaluators can fluidly click across different blocks (Text, Diagrams, or Error bounding boxes) directly on the Canvas. The right-hand panel accurately detects these selections and hot-swaps active data to exclusively evaluate that specific block.
- **Deep Store Synchronization:** Added bidirectional event listeners between the `ocrChat` canvas states and the `eduvizSlice`. Block selections on the canvas instantly synchronize into Redux to keep the panel UI contextually relevant.
- **Global Evaluation Metadata:** Consolidated a global toolbar across the bottom to assign overarching document properties (e.g., `Subject`, `Language`, `Grade level`), effectively reducing interface clutter.
- **Unified Submission Hook:** The submittal logic dynamically packages every standalone annotated block into an aggregated `annotatedBlocks` JSON cluster wrapped tightly alongside the global metadata for backend consumption.
- **State Rehydration:** Overhauled the load parser within `fetchEduvizSessionById.fulfilled`. Old legacy sessions dynamically unpack the newly-routed `annotatedBlocks` payload off the wire—seamlessly re-injecting drawn error boxes, canvas states, and rubric bindings directly upon browser reload.
