### PR TITLE
Improved Error Handling for Session Creation

### DIFF
--- a/src/features/chat/components/MessageInput.jsx
+++ b/src/features/chat/components/MessageInput.jsx
@@ -512,7 +512,7 @@ const hasAttachments = !!selectedModel &&
           await streamMessageCompare({ sessionId: result.id, content, modelAId: result.model_a?.id, modelBId: result.model_b?.id, parentMessageIds: [], language: messageLanguage, imageUrl, imagePath, audioUrl, audioPath, docUrl, docPath });
         }
       } catch (error) {
-        toast.error('Failed to create session');
+        toast.error(error?.message || 'Failed to create session');
         console.error('Session creation error:', error);
       } finally {
         setIsCreatingSession(false);

--- a/src/features/chat/store/chatSlice.js
+++ b/src/features/chat/store/chatSlice.js
@@ -6,15 +6,19 @@ import { endpoints } from '../../../shared/api/endpoints';
 
 export const createSession = createAsyncThunk(
   'chat/createSession',
-  async ({ mode, modelA, modelB, type, metadata }) => {
-    const response = await apiClient.post(endpoints.sessions.create, {
-      mode,
-      model_a_id: modelA,
-      model_b_id: modelB,
-      session_type: type,
-      metadata: metadata || {},
-    });
-    return response.data;
+  async ({ mode, modelA, modelB, type, metadata }, { rejectWithValue }) => {
+    try {
+      const response = await apiClient.post(endpoints.sessions.create, {
+        mode,
+        model_a_id: modelA,
+        model_b_id: modelB,
+        session_type: type,
+        metadata: metadata || {},
+      });
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { message: 'Failed to create session' });
+    }
   }
 );
 


### PR DESCRIPTION
# Description
This PR improves the user experience when session creation fails (e.g., due to authentication requirements or daily message limits) by displaying the specific reason from the backend.

## Key Changes
- **Redux Thunk Update**: Modified `createSession` in [chatSlice.js](cci:7://file:///d:/Arena/Chat-Arena-Frontend/src/features/chat/store/chatSlice.js:0:0-0:0) to use `rejectWithValue`. This ensures that 403/429 error responses from the backend are properly captured in the action payload.
- **Dynamic Error Toasts**: Updated [MessageInput.jsx](cci:7://file:///d:/Arena/Chat-Arena-Frontend/src/features/chat/components/MessageInput.jsx:0:0-0:0) to read the [message](cci:1://file:///d:/Arena/Chat-Arena-Backend/backend/message/utlis.py:214:4-218:42) field from the error payload.
    - **Before**: Always showed "Failed to create session".
    - **After**: Shows "You have reached the daily limit of 15 messages..." or "You must be signed in to create a direct or compare mode session."

## Verification
- Attempted to create a `direct` mode session as an anonymous user; snackbar correctly displayed the "must be signed in" message.
- Verified that generic errors still fall back to "Failed to create session".
